### PR TITLE
Automation Account Fixes. Close #3. Close #20.

### DIFF
--- a/AzureBot/Forms/EntityForms.cs
+++ b/AzureBot/Forms/EntityForms.cs
@@ -95,7 +95,7 @@
 
                         return Task.FromResult(true);
                     }))
-               .Confirm("Would you like to run runbook '{RunbookName}'?")
+               .Confirm("Would you like to run runbook '{RunbookName}' of automation acccount '{AutomationAccountName}'?")
                .Build();
         }
 


### PR DESCRIPTION
Fix two issues related to Automation accounts when trying to start a runbook:

1. If there are no automation accounts available we now show a message notifying the user. Previously, the BOT was asking to select an automation account (issue #3)
2. If there is only one automation account it will be selected and it won't prompt the user. Previously, the BOT was asking the user to select an automation account (issue #20). Also updated the prompt confirm message to include the automation account name.
