### PR TITLE
Runbook fixes and enhancements, more detailed list VM status

### DIFF
--- a/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
+++ b/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
@@ -44,12 +44,12 @@
       <HintPath>..\packages\Microsoft.Azure.Common.2.1.0\lib\net45\Microsoft.Azure.Common.NetFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Management.Compute, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Management.Compute.9.1.0\lib\net40\Microsoft.Azure.Management.Compute.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Management.Automation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.Automation.2.0.1\lib\net40\Microsoft.Azure.Management.Automation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Management.Automation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Management.Automation.2.0.0\lib\net40\Microsoft.Azure.Management.Automation.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Management.Compute, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.Compute.9.1.0\lib\net40\Microsoft.Azure.Management.Compute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.ResourceManager, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -68,8 +68,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/AzureBot.Azure.Management/Models/VirtualMachine.cs
+++ b/AzureBot.Azure.Management/Models/VirtualMachine.cs
@@ -12,5 +12,12 @@
         public string Name { get; set; }
 
         public VirtualMachinePowerState PowerState { get; set; }
+
+        public string Size { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Name} (Status: {PowerState}, ResourceGroup: {ResourceGroup}, Size: {Size})";
+        }
     }
 }

--- a/AzureBot.Azure.Management/ResourceManagement/AzureRepository.cs
+++ b/AzureBot.Azure.Management/ResourceManagement/AzureRepository.cs
@@ -57,7 +57,8 @@
                         SubscriptionId = subscriptionId,
                         ResourceGroup = resourceGroupName,
                         Name = vm.Name,
-                        PowerState = GetVirtualMachinePowerState(vmStatus?.Code.ToLower() ?? VirtualMachinePowerState.Unknown.ToString())
+                        PowerState = GetVirtualMachinePowerState(vmStatus?.Code.ToLower() ?? VirtualMachinePowerState.Unknown.ToString()),
+                        Size = response.VirtualMachine.HardwareProfile.VirtualMachineSize
                     };
                 });
 

--- a/AzureBot.Azure.Management/app.config
+++ b/AzureBot.Azure.Management/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/AzureBot.Azure.Management/packages.config
+++ b/AzureBot.Azure.Management/packages.config
@@ -3,12 +3,12 @@
   <package id="Hyak.Common" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Management.Automation" version="2.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Management.Automation" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.Compute" version="9.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.Resources" version="2.20.0-preview" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net452" />
 </packages>

--- a/AzureBot/AzureBot.csproj
+++ b/AzureBot/AzureBot.csproj
@@ -54,12 +54,32 @@
       <HintPath>..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=1.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Builder.1.2.3\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=1.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.1.2.4\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.FormFlow.Json, Version=1.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.1.2.4\lib\net46\Microsoft.Bot.Builder.FormFlow.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bot.Connector.1.1.0.0\lib\net45\Microsoft.Bot.Connector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.2.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.2.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.2.2\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.2.2\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -91,7 +111,27 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.0.0\lib\net46\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.0.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.0.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -99,6 +139,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1-rc2-24027\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
@@ -169,7 +213,10 @@
       <Name>AzureBot.Azure.Management</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/AzureBot/Dialogs/ActionDialog.cs
+++ b/AzureBot/Dialogs/ActionDialog.cs
@@ -223,7 +223,7 @@
             }
             else
             {
-                await context.PostAsync($"No automations accounts were found in the current subscription.");
+                await context.PostAsync($"No automations accounts were found in the current subscription. Please create an Azure automation account or switch to a subscription which has an automation account in it.");
                 context.Wait(this.MessageReceived);
             }
         }

--- a/AzureBot/Dialogs/ActionDialog.cs
+++ b/AzureBot/Dialogs/ActionDialog.cs
@@ -340,6 +340,7 @@
         private static async Task CheckLongRunningOperationStatus<T>(
             IDialogContext context,
             RunbookJob runbookJob,
+            string resourceId,
             Func<string, string, string, string, string, bool, Task<T>> getOperationStatusAsync,
             Func<T, bool> completionCondition,
             Func<T, T, string> getOperationStatusMessage,
@@ -348,7 +349,7 @@
             var lastOperationStatus = default(T);
             do
             {
-                var accessToken = await context.GetAccessToken(resourceId.Value).ConfigureAwait(false);
+                var accessToken = await context.GetAccessToken(resourceId).ConfigureAwait(false);
                 var subscriptionId = context.GetSubscriptionId();
 
                 var newOperationStatus = await getOperationStatusAsync(accessToken, subscriptionId, runbookJob.ResourceGroupName, runbookJob.AutomationAccountName, runbookJob.JobId, true).ConfigureAwait(false);
@@ -493,6 +494,7 @@
                 CheckLongRunningOperationStatus(
                     context,
                     runbookJob,
+                    resourceId.Value,
                     new AzureRepository().GetAutomationJobAsync,
                     rj => rj.EndDateTime.HasValue,
                     (previous, last) =>

--- a/AzureBot/Dialogs/ActionDialog.cs
+++ b/AzureBot/Dialogs/ActionDialog.cs
@@ -161,7 +161,7 @@
                      string.Empty,
                     (current, next) =>
                     {
-                        return current += $"\n\r• {next.Name} ({next.PowerState})";
+                        return current += $"\n\r• {next}";
                     });
 
                 await context.PostAsync($"Available VMs are:\r\n {virtualMachinesText}");

--- a/AzureBot/Dialogs/ActionDialog.cs
+++ b/AzureBot/Dialogs/ActionDialog.cs
@@ -244,21 +244,54 @@
                 // obtain the name specified by the user - text in LUIS result is different
                 var runbookName = runbookEntity.GetEntityOriginalText(result.Query);
 
-                // ensure that the runbook exists
-                var selectedAutomationAccounts = availableAutomationAccounts.Where(x => x.Runbooks.Any(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)));
+                EntityRecommendation automationAccountEntity;
 
-                if (selectedAutomationAccounts == null || !selectedAutomationAccounts.Any())
+                if (result.TryFindEntity("AutomationAccount", out automationAccountEntity))
                 {
-                    await context.PostAsync($"The '{runbookName}' runbook was not found in any of your automation accounts.");
-                    context.Wait(this.MessageReceived);
-                    return;
+                    // obtain the name specified by the user - text in LUIS result is different
+                    var automationAccountName = automationAccountEntity.GetEntityOriginalText(result.Query);
+
+                    var selectedAutomationAccount = availableAutomationAccounts.SingleOrDefault(x => x.AutomationAccountName.Equals(automationAccountName, StringComparison.InvariantCultureIgnoreCase));
+
+                    if (selectedAutomationAccount == null)
+                    {
+                        await context.PostAsync($"The '{automationAccountName}' automation account was not found in the current subscription");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    // ensure that the runbook exists in the specified automation account
+                    if (!selectedAutomationAccount.Runbooks.Any(x => x.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)))
+                    {
+                        await context.PostAsync($"The '{runbookName}' runbook was not found in the '{automationAccountName}' automation account.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    runbookEntity.Entity = runbookName;
+                    runbookEntity.Type = "RunbookName";
+
+                    automationAccountEntity.Entity = selectedAutomationAccount.AutomationAccountName;
+                    automationAccountEntity.Type = "AutomationAccountName";
                 }
+                else
+                {
+                    // ensure that the runbook exists in at least one of the automation accounts
+                    var selectedAutomationAccounts = availableAutomationAccounts.Where(x => x.Runbooks.Any(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)));
 
-                runbookEntity.Entity = runbookName;
-                runbookEntity.Type = "RunbookName";
+                    if (selectedAutomationAccounts == null || !selectedAutomationAccounts.Any())
+                    {
+                        await context.PostAsync($"The '{runbookName}' runbook was not found in any of your automation accounts.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
 
-                // todo: handle runbooks with same name in different automation accounts
-                availableAutomationAccounts = selectedAutomationAccounts.ToList();
+                    runbookEntity.Entity = runbookName;
+                    runbookEntity.Type = "RunbookName";
+
+                    // todo: handle runbooks with same name in different automation accounts
+                    availableAutomationAccounts = selectedAutomationAccounts.ToList();
+                }
             }
 
             if (availableAutomationAccounts.Any())

--- a/AzureBot/Forms/EntityForms.cs
+++ b/AzureBot/Forms/EntityForms.cs
@@ -45,7 +45,7 @@
                     foreach (var vm in state.AvailableVMs)
                     {
                         field
-                            .AddDescription(vm.Name, vm.Name)
+                            .AddDescription(vm.Name, vm.ToString())
                             .AddTerms(vm.Name, vm.Name);
                     }
 

--- a/AzureBot/Web.config
+++ b/AzureBot/Web.config
@@ -86,6 +86,10 @@
         <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.4.0" newVersion="1.2.4.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/AzureBot/packages.config
+++ b/AzureBot/packages.config
@@ -8,30 +8,42 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="1.2.3" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="1.2.4" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector" version="1.1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.2.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.2.2" targetFramework="net46" />
   <package id="Microsoft.Identity.Client" version="1.0.304142221-alpha" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.11.305310302-alpha" targetFramework="net46" />
   <package id="Microsoft.Rest.ClientRuntime" version="1.8.2" targetFramework="net46" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net46" />
+  <package id="System.AppContext" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections" version="4.0.11-rc2-24027" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.0.12-rc2-24027" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.ComponentModel" version="4.0.1-rc2-24027" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.11-rc2-24027" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.0.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tools" version="4.0.1-rc2-24027" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.11-rc2-24027" targetFramework="net46" />
   <package id="System.IO" version="4.1.0-rc2-24027" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.0.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0-rc2-24027" targetFramework="net46" />
   <package id="System.Linq.Expressions" version="4.0.11-rc2-24027" targetFramework="net46" />
   <package id="System.Net.Http" version="4.0.1-rc2-24027" targetFramework="net46" />
   <package id="System.Net.Primitives" version="4.0.11-rc2-24027" targetFramework="net46" />
   <package id="System.Reflection" version="4.1.0-rc2-24027" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.1-rc2-24027" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.0.1-rc2-24027" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.1-rc2-24027" targetFramework="net46" />
   <package id="System.Runtime" version="4.1.0-rc2-24027" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.1.0-rc2-24027" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.1.0-rc2-24027" targetFramework="net46" />
   <package id="System.Runtime.Serialization.Json" version="4.0.2-rc2-24027" targetFramework="net46" />
   <package id="System.Runtime.Serialization.Primitives" version="4.1.1-rc2-24027" targetFramework="net46" />

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 This is the home of the code used to run the AzureBot and is built with the [Microsoft Bot framework] (http://docs.botframework.com/), [Microsoft Bot Builder C# SDK](http://docs.botframework.com/sdkreference/csharp/), and the [Azure Resource Manager Nuget package](https://www.nuget.org/packages/Microsoft.Azure.Management.ResourceManager).
 This first implementation focuses on authenticating to the user's Azure subscription, selecting and switching subscriptions, starting and stopping RM-based virtual machines, and listing and starting Azure Automation runbooks. 
 If you're interested in contributing to this project or providing early feedback, please reach out to azurebot at microsoft dot c o m or submit a pull request.  If you find issues with or desire improvements for the existing functionality, please file an issue here in GitHub.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
This resolves issues:
* Runbooks not sending the status back in Slack Issue #40  
* Being able to handle stopped, suspended, and all other runbook statuses #21
Adds functionality:
* VM status displays resource group and VM size
* support for start runbook "from _name_ automation account"

For more detailed commit history, see pull request #37 #38 #39 #40 #41 #42 