### PR TITLE
Botbuilder v3

### DIFF
--- a/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
+++ b/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
@@ -48,12 +48,20 @@
       <HintPath>..\packages\Microsoft.Azure.Management.Automation.2.0.1\lib\net40\Microsoft.Azure.Management.Automation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Management.Compute, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Management.Compute.9.1.0\lib\net40\Microsoft.Azure.Management.Compute.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Management.Compute, Version=13.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.Compute.13.0.4-prerelease\lib\net45\Microsoft.Azure.Management.Compute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.ResourceManager, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Management.Resources.2.20.0-preview\lib\net40\Microsoft.Azure.ResourceManager.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Management.ResourceManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.ResourceManager.1.1.3-preview\lib\net45\Microsoft.Azure.Management.ResourceManager.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.1.0\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.1.0\lib\net45\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -84,6 +92,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
+++ b/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
@@ -32,8 +32,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Data\MockData.cs" />
+    <Compile Include="Models\AutomationAccount.cs" />
+    <Compile Include="Models\Runbook.cs" />
+    <Compile Include="Models\RunbookJob.cs" />
+    <Compile Include="Models\RunbookParameter.cs" />
+    <Compile Include="Models\VirtualMachine.cs" />
+    <Compile Include="Models\Subscription.cs" />
+    <Compile Include="Models\VirtualMachinePowerState.cs" />
+    <Compile Include="ResourceManagement\AzureRepository.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Data\MockData.json" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hyak.Common.1.1.0\lib\net45\Hyak.Common.dll</HintPath>
+      <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -56,8 +75,9 @@
       <HintPath>..\packages\Microsoft.Azure.Management.ResourceManager.1.1.3-preview\lib\net45\Microsoft.Azure.Management.ResourceManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.1.0\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.1\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -76,55 +96,30 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Data\MockData.cs" />
-    <Compile Include="Models\AutomationAccount.cs" />
-    <Compile Include="Models\Runbook.cs" />
-    <Compile Include="Models\RunbookJob.cs" />
-    <Compile Include="Models\RunbookParameter.cs" />
-    <Compile Include="Models\VirtualMachine.cs" />
-    <Compile Include="Models\Subscription.cs" />
-    <Compile Include="Models\VirtualMachinePowerState.cs" />
-    <Compile Include="ResourceManagement\AzureRepository.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <EmbeddedResource Include="Data\MockData.json" />
-    <None Include="app.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
+++ b/AzureBot.Azure.Management/AzureBot.Azure.Management.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AzureBot.Azure.Management</RootNamespace>
     <AssemblyName>AzureBot.Azure.Management</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,7 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
+      <HintPath>..\packages\Hyak.Common.1.1.0\lib\net45\Hyak.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -67,23 +68,15 @@
       <HintPath>..\packages\Microsoft.Azure.Management.Automation.2.0.1\lib\net40\Microsoft.Azure.Management.Automation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Management.Compute, Version=13.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Management.Compute.13.0.4-prerelease\lib\net45\Microsoft.Azure.Management.Compute.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Management.Compute, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.Compute.9.1.0\lib\net40\Microsoft.Azure.Management.Compute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Management.ResourceManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Management.ResourceManager.1.1.3-preview\lib\net45\Microsoft.Azure.Management.ResourceManager.dll</HintPath>
+    <Reference Include="Microsoft.Azure.ResourceManager, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.Resources.2.20.0-preview\lib\net40\Microsoft.Azure.ResourceManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.1\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.1.0\lib\net45\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
@@ -96,19 +89,19 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
@@ -120,6 +113,13 @@
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AzureBot.Azure.Management/ResourceManagement/AzureRepository.cs
+++ b/AzureBot.Azure.Management/ResourceManagement/AzureRepository.cs
@@ -6,12 +6,12 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
-    using Microsoft.Azure;
     using Microsoft.Azure.Management.Automation;
     using Microsoft.Azure.Management.Compute;
     using Microsoft.Azure.Management.ResourceManager;
     using Models;
     using AzureModels = Microsoft.Azure.Management.Automation.Models;
+    using Microsoft.Azure;
     public class AzureRepository
     {
         public async Task<IEnumerable<Subscription>> ListSubscriptionsAsync(string accessToken)
@@ -121,31 +121,34 @@
             }
         }
 
-        public async void StartVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
+        public async Task<bool> StartVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
         {
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
                 await client.VirtualMachines.StartAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
             }
+            return true;
         }
 
-        public async void PowerOffVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
+        public async Task<bool> PowerOffVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
         {
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
                 await client.VirtualMachines.PowerOffAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
             }
+            return true;
         }
 
-        public async void DeallocateVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
+        public async Task<bool> DeallocateVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
         {
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
                 await client.VirtualMachines.DeallocateAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
             }
+            return true;
         }
 
         public async Task<RunbookJob> StartRunbookAsync(

--- a/AzureBot.Azure.Management/ResourceManagement/AzureRepository.cs
+++ b/AzureBot.Azure.Management/ResourceManagement/AzureRepository.cs
@@ -5,13 +5,13 @@
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Rest;
+    using Microsoft.Azure;
     using Microsoft.Azure.Management.Automation;
     using Microsoft.Azure.Management.Compute;
-    using Microsoft.Azure.Subscriptions;
+    using Microsoft.Azure.Management.ResourceManager;
     using Models;
     using AzureModels = Microsoft.Azure.Management.Automation.Models;
-    using TokenCredentials = Microsoft.Azure.TokenCloudCredentials;
-
     public class AzureRepository
     {
         public async Task<IEnumerable<Subscription>> ListSubscriptionsAsync(string accessToken)
@@ -21,7 +21,7 @@
             using (SubscriptionClient client = new SubscriptionClient(credentials))
             {
                 var subscriptionsResult = await client.Subscriptions.ListAsync().ConfigureAwait(false);
-                var subscriptions = subscriptionsResult.Subscriptions.OrderBy(x => x.DisplayName).Select(sub => new Subscription { SubscriptionId = sub.SubscriptionId, DisplayName = sub.DisplayName }).ToList();
+                var subscriptions = subscriptionsResult.OrderBy(x => x.DisplayName).Select(sub => new Subscription { SubscriptionId = sub.SubscriptionId, DisplayName = sub.DisplayName }).ToList();
                 return subscriptions;
             }
         }
@@ -35,8 +35,8 @@
                 var subscriptionsResult = await client.Subscriptions.GetAsync(subscriptionId, CancellationToken.None);
                 return new Subscription
                 {
-                    SubscriptionId = subscriptionsResult.Subscription.SubscriptionId,
-                    DisplayName = subscriptionsResult.Subscription.DisplayName
+                    SubscriptionId = subscriptionsResult.SubscriptionId,
+                    DisplayName = subscriptionsResult.DisplayName
                 };
             }
         }
@@ -46,19 +46,19 @@
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
-                var virtualMachinesResult = await client.VirtualMachines.ListAllAsync(null).ConfigureAwait(false);
-                var all = virtualMachinesResult.VirtualMachines.Select(async (vm) =>
+                var virtualMachinesResult = await client.VirtualMachines.ListAllAsync().ConfigureAwait(false);
+                var all = virtualMachinesResult.Select(async (vm) =>
                 {
                     var resourceGroupName = GetResourceGroup(vm.Id);
-                    var response = await client.VirtualMachines.GetWithInstanceViewAsync(resourceGroupName, vm.Name);
-                    var vmStatus = response.VirtualMachine.InstanceView.Statuses.Where(p => p.Code.ToLower().StartsWith("powerstate/")).FirstOrDefault();
+                    var response = await client.VirtualMachines.GetAsync(resourceGroupName, vm.Name);
+                    var vmStatus = response.InstanceView.Statuses.Where(p => p.Code.ToLower().StartsWith("powerstate/")).FirstOrDefault();
                     return new VirtualMachine
                     {
                         SubscriptionId = subscriptionId,
                         ResourceGroup = resourceGroupName,
                         Name = vm.Name,
                         PowerState = GetVirtualMachinePowerState(vmStatus?.Code.ToLower() ?? VirtualMachinePowerState.Unknown.ToString()),
-                        Size = response.VirtualMachine.HardwareProfile.VirtualMachineSize
+                        Size = response.HardwareProfile.VmSize
                     };
                 });
 
@@ -68,7 +68,7 @@
 
         public async Task<IEnumerable<AutomationAccount>> ListAutomationAccountsAsync(string accessToken, string subscriptionId)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -85,7 +85,7 @@
 
         public async Task<IEnumerable<AutomationAccount>> ListRunbooksAsync(string accessToken, string subscriptionId)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -104,7 +104,7 @@
 
         public async Task<IEnumerable<AutomationAccount>> ListRunbookJobsAsync(string accessToken, string subscriptionId)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -121,33 +121,30 @@
             }
         }
 
-        public async Task<bool> StartVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
+        public async void StartVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
         {
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
-                var status = await client.VirtualMachines.StartAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
-                return status.Status != Microsoft.Azure.Management.Compute.Models.ComputeOperationStatus.Failed;
+                await client.VirtualMachines.StartAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
             }
         }
 
-        public async Task<bool> PowerOffVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
+        public async void PowerOffVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
         {
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
-                var status = await client.VirtualMachines.PowerOffAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
-                return status.Status != Microsoft.Azure.Management.Compute.Models.ComputeOperationStatus.Failed;
+                await client.VirtualMachines.PowerOffAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
             }
         }
 
-        public async Task<bool> DeallocateVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
+        public async void DeallocateVirtualMachineAsync(string accessToken, string subscriptionId, string resourceGroupName, string virtualMachineName)
         {
             var credentials = new TokenCredentials(subscriptionId, accessToken);
             using (var client = new ComputeManagementClient(credentials))
             {
-                var status = await client.VirtualMachines.DeallocateAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
-                return status.Status != Microsoft.Azure.Management.Compute.Models.ComputeOperationStatus.Failed;
+                await client.VirtualMachines.DeallocateAsync(resourceGroupName, virtualMachineName).ConfigureAwait(false);
             }
         }
 
@@ -159,7 +156,7 @@
             string runbookName, 
             IDictionary<string, string> runbookParameters = null)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var client = new AutomationManagementClient(credentials))
             {
@@ -189,7 +186,7 @@
 
         public async Task<RunbookJob> GetAutomationJobAsync(string accessToken, string subscriptionId, string resourceGroupName, string automationAccountName, string jobId, bool configureAwait = false)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -213,7 +210,7 @@
 
         public async Task<string> GetAutomationJobOutputAsync(string accessToken, string subscriptionId, string resourceGroupName, string automationAccountName, string jobId)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -230,7 +227,7 @@
             string automationAccountName,
             string runbookName)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -249,7 +246,7 @@
 
         private async Task<IEnumerable<Runbook>> ListAutomationRunbooks(string accessToken, string subscriptionId, string resourceGroupName, string automationAccountName, params string[] runbooksStateFilter)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -270,7 +267,7 @@
 
         private async Task<IEnumerable<RunbookJob>> ListAutomationJobs(string accessToken, string subscriptionId, string resourceGroupName, string automationAccountName)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {
@@ -295,7 +292,7 @@
             string automationAccountName,
             string runbookName)
         {
-            var credentials = new TokenCredentials(subscriptionId, accessToken);
+            var credentials = new TokenCloudCredentials(subscriptionId, accessToken);
 
             using (var automationClient = new AutomationManagementClient(credentials))
             {

--- a/AzureBot.Azure.Management/app.config
+++ b/AzureBot.Azure.Management/app.config
@@ -3,8 +3,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/AzureBot.Azure.Management/app.config
+++ b/AzureBot.Azure.Management/app.config
@@ -3,8 +3,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/AzureBot.Azure.Management/packages.config
+++ b/AzureBot.Azure.Management/packages.config
@@ -1,16 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyak.Common" version="1.0.2" targetFramework="net452" />
-  <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
+  <package id="Hyak.Common" version="1.1.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.Management.Automation" version="2.0.1" targetFramework="net452" />
-  <package id="Microsoft.Azure.Management.Compute" version="13.0.4-prerelease" targetFramework="net452" />
-  <package id="Microsoft.Azure.Management.ResourceManager" version="1.1.3-preview" targetFramework="net452" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net452" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
-  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net452" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.1" targetFramework="net452" />
-  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Microsoft.Azure.Management.Compute" version="9.1.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.Management.Resources" version="2.20.0-preview" targetFramework="net46" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net46" />
 </packages>

--- a/AzureBot.Azure.Management/packages.config
+++ b/AzureBot.Azure.Management/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyak.Common" version="1.1.0" targetFramework="net452" />
+  <package id="Hyak.Common" version="1.0.2" targetFramework="net452" />
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.Automation" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.Compute" version="13.0.4-prerelease" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.ResourceManager" version="1.1.3-preview" targetFramework="net452" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net452" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.1" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>

--- a/AzureBot.Azure.Management/packages.config
+++ b/AzureBot.Azure.Management/packages.config
@@ -4,11 +4,13 @@
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.Automation" version="2.0.1" targetFramework="net452" />
-  <package id="Microsoft.Azure.Management.Compute" version="9.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Management.Resources" version="2.20.0-preview" targetFramework="net452" />
+  <package id="Microsoft.Azure.Management.Compute" version="13.0.4-prerelease" targetFramework="net452" />
+  <package id="Microsoft.Azure.Management.ResourceManager" version="1.1.3-preview" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net452" />
 </packages>

--- a/AzureBot/AzureBot.csproj
+++ b/AzureBot/AzureBot.csproj
@@ -95,8 +95,8 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Rest.ClientRuntime, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.1.8.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.1.0\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -200,7 +200,9 @@
     <Compile Include="ContextConstants.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="LuisModel\AzureBot.json" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/AzureBot/AzureBot.csproj
+++ b/AzureBot/AzureBot.csproj
@@ -42,136 +42,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.0.0-rc2-240\lib\netstandard1.1\Autofac.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Builder.3.0.1\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Builder.3.0.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.2.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.2.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.2.2\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.2.2\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Identity.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Identity.Client.Platform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.11.305310302-alpha\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.11.305310302-alpha\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.2.33, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.1.0\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.AppContext.4.0.0\lib\net46\System.AppContext.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.StackTrace.4.0.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.20622.1351, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.2.206221351\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.4.0.0\lib\net46\System.IO.FileSystem.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1-rc2-24027\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.DynamicData" />
-    <Reference Include="System.Web.Entity" />
-    <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.EnterpriseServices" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="default.htm" />
     <Content Include="Global.asax" />
     <Content Include="Web.config">
@@ -200,10 +70,10 @@
     <Compile Include="ContextConstants.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="LuisModel\AzureBot.json" />
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="LuisModel\AzureBot.json" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -218,8 +88,149 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Reference Include="AuthBot, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AuthBot.3.0.2-alpha\lib\net40\AuthBot.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.0.0-rc3-309\lib\net451\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.3.0.1\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.3.0.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Identity.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Identity.Client.Platform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.Platform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.12.0.827, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.12.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.12.0.827, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.12.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.0.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.0.0\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.2.33, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.0.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.0.0\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.1\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.0.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.20622.1351, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.2.206221351\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.2.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.0.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.0.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.1.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -249,6 +260,11 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/AzureBot/AzureBot.csproj
+++ b/AzureBot/AzureBot.csproj
@@ -137,8 +137,8 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.0.0\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.1\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.1.8.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/AzureBot/Controllers/MessagesController.cs
+++ b/AzureBot/Controllers/MessagesController.cs
@@ -8,6 +8,7 @@
     using System.Net.Http;
     using System.Web.Http.Description;
     using System.Diagnostics;
+
     [BotAuthentication]
     public class MessagesController : ApiController
     {
@@ -16,7 +17,7 @@
         /// Receive a message from a user and reply to it
         /// </summary>
         [ResponseType(typeof(void))]
-        public virtual async Task<HttpResponseMessage> Post([FromBody]Activity activity)
+        public virtual async Task<HttpResponseMessage> Post([FromBody] Activity activity)
         {
             if (activity != null)
             {

--- a/AzureBot/Controllers/MessagesController.cs
+++ b/AzureBot/Controllers/MessagesController.cs
@@ -16,7 +16,6 @@
         /// POST: api/Messages
         /// Receive a message from a user and reply to it
         /// </summary>
-        [ResponseType(typeof(void))]
         public virtual async Task<HttpResponseMessage> Post([FromBody] Activity activity)
         {
             if (activity != null)

--- a/AzureBot/Dialogs/ActionDialog.cs
+++ b/AzureBot/Dialogs/ActionDialog.cs
@@ -7,24 +7,24 @@
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    //using AuthBot;
-    //using AuthBot.Dialogs;
+    using AuthBot;
+    using AuthBot.Dialogs;
     using Azure.Management.Models;
     using Azure.Management.ResourceManagement;
-    using Forms;
     using Helpers;
+    using Forms;
     using Microsoft.Bot.Builder.Dialogs;
     using Microsoft.Bot.Builder.FormFlow;
     using Microsoft.Bot.Builder.Luis;
     using Microsoft.Bot.Builder.Luis.Models;
     using Microsoft.Bot.Connector;
-
+    
     [LuisModel("1b58a513-e98a-4a13-a5c4-f61ac6dc6c84", "0e64d2ae951547f692182b4ae74262cb")]
     [Serializable]
     public class ActionDialog : LuisDialog<string>
     {
         private static Lazy<string> resourceId = new Lazy<string>(() => ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
-
+        
         [LuisIntent("")]
         [LuisIntent("None")]
         public async Task None(IDialogContext context, LuisResult result)
@@ -52,7 +52,6 @@
             context.Wait(this.MessageReceived);
         }
 
-
         protected override async Task MessageReceived(IDialogContext context, IAwaitable<IMessageActivity> item)
         {
             var message = await item;
@@ -64,30 +63,30 @@
                 return;
             }
 
-            //var accessToken = await context.GetAccessToken(resourceId.Value);
+            var accessToken = await context.GetAccessToken(resourceId.Value);
 
-            //if (string.IsNullOrEmpty(accessToken))
-            //{
-            if (message.Text.ToLowerInvariant().Contains("login"))
+            if (string.IsNullOrEmpty(accessToken))
             {
-                //await context.Forward(new AzureAuthDialog(resourceId.Value), this.ResumeAfterAuth, message, CancellationToken.None);
+                if (message.Text.ToLowerInvariant().Contains("login"))
+                {
+                    await context.Forward(new AzureAuthDialog(resourceId.Value), this.ResumeAfterAuth, message, CancellationToken.None);
+                }
+                else
+                {
+                    await this.Help(context, new LuisResult());
+                }
             }
             else
             {
-                await this.Help(context, new LuisResult());
+                if (string.IsNullOrEmpty(context.GetSubscriptionId()))
+                {
+                    await this.UseSubscriptionAsync(context, new LuisResult());
+                }
+                else
+                {
+                    await base.MessageReceived(context, item);
+                }
             }
-            //}
-            //else
-            //{
-            //    if (string.IsNullOrEmpty(context.GetSubscriptionId()))
-            //    {
-            //        await this.UseSubscriptionAsync(context, new LuisResult());
-            //    }
-            //    else
-            //    {
-            //        await base.MessageReceived(context, item);
-            //    }
-            //}
         }
 
         private static async Task CheckLongRunningOperationStatus<T>(
@@ -116,1025 +115,1025 @@
         }
 
 
-        //[LuisIntent("ListSubscriptions")]
-        //public async Task ListSubscriptionsAsync(IDialogContext context, LuisResult result)
-        //{
-        //    int index = 0;
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptions = await new AzureRepository().ListSubscriptionsAsync(accessToken);
-
-        //    var subscriptionsText = subscriptions.Aggregate(
-        //        string.Empty,
-        //        (current, next) =>
-        //            {
-        //                index++;
-        //                return current += $"\r\n{index}. {next.DisplayName}";
-        //            });
-
-        //    await context.PostAsync($"Your subscriptions are: {subscriptionsText}");
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("CurrentSubscription")]
-        //public async Task GetCurrentSubscriptionAsync(IDialogContext context, LuisResult result)
-        //{
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    var currentSubscription = await new AzureRepository().GetSubscription(accessToken, subscriptionId);
-
-        //    await context.PostAsync($"Your current subscription is '{currentSubscription.DisplayName}'.");
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("UseSubscription")]
-        //public async Task UseSubscriptionAsync(IDialogContext context, LuisResult result)
-        //{
-        //    EntityRecommendation subscriptionEntity;
-
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        context.Wait(this.MessageReceived);
-        //        return;
-        //    }
-
-        //    var availableSubscriptions = await new AzureRepository().ListSubscriptionsAsync(accessToken);
-
-        //    // check if the user specified a subscription name in the command
-        //    if (result.TryFindEntity("Subscription", out subscriptionEntity))
-        //    {
-        //        // obtain the name specified by the user - text in LUIS result is different
-        //        var subscriptionName = subscriptionEntity.GetEntityOriginalText(result.Query);
-
-        //        // ensure that the subscription exists
-        //        var selectedSubscription = availableSubscriptions.FirstOrDefault(p => p.DisplayName.Equals(subscriptionName, StringComparison.InvariantCultureIgnoreCase));
-        //        if (selectedSubscription == null)
-        //        {
-        //            await context.PostAsync($"The '{subscriptionName}' subscription was not found.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-
-        //        subscriptionEntity.Entity = selectedSubscription.DisplayName;
-        //        subscriptionEntity.Type = "SubscriptionId";
-        //    }
-
-        //    var formState = new SubscriptionFormState(availableSubscriptions);
-
-        //    if (availableSubscriptions.Count() == 1)
-        //    {
-        //        formState.SubscriptionId = availableSubscriptions.Single().SubscriptionId;
-        //        formState.DisplayName = availableSubscriptions.Single().DisplayName;
-        //    }
-
-        //    var form = new FormDialog<SubscriptionFormState>(
-        //        formState,
-        //        EntityForms.BuildSubscriptionForm,
-        //        FormOptions.PromptInStart,
-        //        result.Entities);
-
-        //    context.Call(form, this.UseSubscriptionFormComplete);
-        //}
-
-        //[LuisIntent("ListVms")]
-        //public async Task ListVmsAsync(IDialogContext context, LuisResult result)
-        //{
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    var virtualMachines = (await new AzureRepository().ListVirtualMachinesAsync(accessToken, subscriptionId)).ToList();
-        //    if (virtualMachines.Any())
-        //    {
-        //        var virtualMachinesText = virtualMachines.Aggregate(
-        //             string.Empty,
-        //            (current, next) =>
-        //            {
-        //                return current += $"\n\r• {next}";
-        //            });
-
-        //        await context.PostAsync($"Available VMs are:\r\n {virtualMachinesText}");
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync("No virtual machines were found in the current subscription.");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("StartVm")]
-        //public async Task StartVmAsync(IDialogContext context, LuisResult result)
-        //{
-        //    await this.ProcessVirtualMachineActionAsync(context, result, Operations.Start, this.StartVirtualMachineFormComplete);
-        //}
-
-        //[LuisIntent("StartAllVms")]
-        //public async Task StartAllVmsAsync(IDialogContext context, LuisResult result)
-        //{
-        //    await this.ProcessAllVirtualMachinesActionAsync(context, result, Operations.Start, this.StartAllVirtualMachinesFormComplete);
-        //}
-
-        //[LuisIntent("StopVm")]
-        //public async Task StopVmAsync(IDialogContext context, LuisResult result)
-        //{
-        //    await this.ProcessVirtualMachineActionAsync(context, result, Operations.Stop, this.StopVirtualMachineFormComplete);
-        //}
-
-        //[LuisIntent("StopAllVms")]
-        //public async Task StopAllVmsAsync(IDialogContext context, LuisResult result)
-        //{
-        //    await this.ProcessAllVirtualMachinesActionAsync(context, result, Operations.Stop, this.StopAllVirtualMachinesFormComplete);
-        //}
-
-        //[LuisIntent("ShutdownVm")]
-        //public async Task ShutdownVmAsync(IDialogContext context, LuisResult result)
-        //{
-        //    await this.ProcessVirtualMachineActionAsync(context, result, Operations.Shutdown, this.ShutdownVirtualMachineFormComplete);
-        //}
-
-        //[LuisIntent("ShutdownAllVms")]
-        //public async Task ShutdownAllVmsAsync(IDialogContext context, LuisResult result)
-        //{
-        //    await this.ProcessAllVirtualMachinesActionAsync(context, result, Operations.Shutdown, this.ShutdownAllVirtualMachinesFormComplete);
-        //}
-
-        //[LuisIntent("ListRunbooks")]
-        //public async Task ListRunbooksAsync(IDialogContext context, LuisResult result)
-        //{
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    var automationAccounts = await new AzureRepository().ListRunbooksAsync(accessToken, subscriptionId);
-
-        //    if (automationAccounts.Any())
-        //    {
-        //        var automationAccountsWithRunbooks = automationAccounts.Where(x => x.Runbooks.Any());
-
-        //        if (automationAccountsWithRunbooks.Any())
-        //        {
-        //            var messageText = "Available runbooks are:";
-
-        //            var singleAutomationAccount = automationAccountsWithRunbooks.Count() == 1;
-
-        //            if (singleAutomationAccount)
-        //            {
-        //                messageText = $"Listing all runbooks from {automationAccountsWithRunbooks.Single().AutomationAccountName}";
-        //            }
-
-        //            var runbooksText = automationAccountsWithRunbooks.Aggregate(
-        //                 string.Empty,
-        //                (current, next) =>
-        //                {
-        //                    var innerRunbooksText = next.Runbooks.Aggregate(
-        //                        string.Empty,
-        //                        (currentRunbooks, nextRunbook) =>
-        //                        {
-        //                            return currentRunbooks += $"\n\r• {nextRunbook}";
-        //                        });
-
-        //                    return current += singleAutomationAccount ? innerRunbooksText : $"\n\r {next.AutomationAccountName}" + innerRunbooksText;
-        //                });
-
-        //            var showDescriptionText = "Type **show runbook <name> description** to get details on any runbook.";
-        //            await context.PostAsync($"{messageText}:\r\n {runbooksText} \r\n\r\n {showDescriptionText}");
-        //        }
-        //        else
-        //        {
-        //            await context.PostAsync($"The automation accounts found in the current subscription doesn't have runbooks.");
-        //        }
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync("No runbooks listed since no automations accounts were found in the current subscription.");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("ListAutomationAccounts")]
-        //public async Task ListAutomationAccountsAsync(IDialogContext context, LuisResult result)
-        //{
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    var automationAccounts = await new AzureRepository().ListAutomationAccountsAsync(accessToken, subscriptionId);
-        //    if (automationAccounts.Any())
-        //    {
-        //        var automationAccountsText = automationAccounts.Aggregate(
-        //             string.Empty,
-        //            (current, next) =>
-        //            {
-        //                return current += $"\n\r• {next.AutomationAccountName}";
-        //            });
-
-        //        await context.PostAsync($"Available automations accounts are:\r\n {automationAccountsText}");
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync("No automations accounts were found in the current subscription.");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("RunRunbook")]
-        //public async Task StartRunbookAsync(IDialogContext context, LuisResult result)
-        //{
-        //    EntityRecommendation runbookEntity;
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    var availableAutomationAccounts = await new AzureRepository().ListRunbooksAsync(accessToken, subscriptionId);
-
-        //    // check if the user specified a runbook name in the command
-        //    if (result.TryFindEntity("Runbook", out runbookEntity))
-        //    {
-        //        // obtain the name specified by the user - text in LUIS result is different
-        //        var runbookName = runbookEntity.GetEntityOriginalText(result.Query);
-
-        //        EntityRecommendation automationAccountEntity;
-
-        //        if (result.TryFindEntity("AutomationAccount", out automationAccountEntity))
-        //        {
-        //            // obtain the name specified by the user - text in LUIS result is different
-        //            var automationAccountName = automationAccountEntity.GetEntityOriginalText(result.Query);
-
-        //            var selectedAutomationAccount = availableAutomationAccounts.SingleOrDefault(x => x.AutomationAccountName.Equals(automationAccountName, StringComparison.InvariantCultureIgnoreCase));
-
-        //            if (selectedAutomationAccount == null)
-        //            {
-        //                await context.PostAsync($"The '{automationAccountName}' automation account was not found in the current subscription");
-        //                context.Wait(this.MessageReceived);
-        //                return;
-        //            }
-
-        //            var runbook = selectedAutomationAccount.Runbooks.SingleOrDefault(x => x.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase));
-
-        //            // ensure that the runbook exists in the specified automation account
-        //            if (runbook == null)
-        //            {
-        //                await context.PostAsync($"The '{runbookName}' runbook was not found in the '{automationAccountName}' automation account.");
-        //                context.Wait(this.MessageReceived);
-        //                return;
-        //            }
-
-        //            if (!runbook.RunbookState.Equals("Published", StringComparison.InvariantCultureIgnoreCase))
-        //            {
-        //                await context.PostAsync($"The '{runbookName}' runbook that you are trying to run is not published (State: {runbook.RunbookState}). Please go the Azure Portal and publish the runbook.");
-        //                context.Wait(this.MessageReceived);
-        //                return;
-        //            }
-
-        //            runbookEntity.Entity = runbookName;
-        //            runbookEntity.Type = "RunbookName";
-
-        //            automationAccountEntity.Entity = selectedAutomationAccount.AutomationAccountName;
-        //            automationAccountEntity.Type = "AutomationAccountName";
-        //        }
-        //        else
-        //        {
-        //            // ensure that the runbook exists in at least one of the automation accounts
-        //            var selectedAutomationAccounts = availableAutomationAccounts.Where(x => x.Runbooks.Any(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)));
-
-        //            if (selectedAutomationAccounts == null || !selectedAutomationAccounts.Any())
-        //            {
-        //                await context.PostAsync($"The '{runbookName}' runbook was not found in any of your automation accounts.");
-        //                context.Wait(this.MessageReceived);
-        //                return;
-        //            }
-
-        //            var runbooks = selectedAutomationAccounts.SelectMany(x => x.Runbooks.Where(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase) 
-        //                                                                    && r.RunbookState.Equals("Published", StringComparison.InvariantCultureIgnoreCase)));
-
-        //            if (runbooks == null || !runbooks.Any())
-        //            {
-        //                await context.PostAsync($"The '{runbookName}' runbook that you are trying to run is not Published. Please go the Azure Portal and publish the runbook.");
-        //                context.Wait(this.MessageReceived);
-        //                return;
-        //            }
-
-        //            runbookEntity.Entity = runbookName;
-        //            runbookEntity.Type = "RunbookName";
-
-        //            // todo: handle runbooks with same name in different automation accounts
-        //            availableAutomationAccounts = selectedAutomationAccounts.ToList();
-        //        }
-        //    }
-
-        //    if (availableAutomationAccounts.Any())
-        //    {
-        //        var formState = new RunbookFormState(availableAutomationAccounts);
-
-        //        if (availableAutomationAccounts.Count() == 1)
-        //        {
-        //            formState.AutomationAccountName = availableAutomationAccounts.Single().AutomationAccountName;
-        //        }
-
-        //        var form = new FormDialog<RunbookFormState>(
-        //            formState,
-        //            EntityForms.BuildRunbookForm,
-        //            FormOptions.PromptInStart,
-        //            result.Entities);
-        //        context.Call(form, this.StartRunbookParametersAsync);
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync($"No automations accounts were found in the current subscription. Please create an Azure automation account or switch to a subscription which has an automation account in it.");
-        //        context.Wait(this.MessageReceived);
-        //    }
-        //}
-
-        //[LuisIntent("StatusJob")]
-        //public async Task StatusJobAsync(IDialogContext context, LuisResult result)
-        //{
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    IList<RunbookJob> automationJobs = context.GetAutomationJobs(subscriptionId);
-        //    if (automationJobs != null && automationJobs.Any())
-        //    {
-        //        var messageBuilder = new StringBuilder();
-        //        messageBuilder.AppendLine("|Id|Runbook|Start Time|End Time|Status|");
-        //        messageBuilder.AppendLine("|---|---|---|---|---|");
-        //        foreach (var job in automationJobs)
-        //        {
-        //            var automationJob = await new AzureRepository().GetAutomationJobAsync(accessToken, subscriptionId, job.ResourceGroupName, job.AutomationAccountName, job.JobId, configureAwait: false);
-        //            var startDateTime = automationJob.StartDateTime?.ToString("g") ?? string.Empty;
-        //            var endDateTime = automationJob.EndDateTime?.ToString("g") ?? string.Empty;
-        //            var status = automationJob.Status ?? string.Empty;
-        //            messageBuilder.AppendLine($"|{job.FriendlyJobId}|{automationJob.RunbookName}|{startDateTime}|{endDateTime}|{status}|");
-        //        }
-
-        //        await context.PostAsync(messageBuilder.ToString());
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync("No Runbook Jobs were created in the current session. To create a new Runbook Job type: Start Runbook.");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("ShowJobOutput")]
-        //public async Task ShowJobOutputAsync(IDialogContext context, LuisResult result)
-        //{
-        //    EntityRecommendation jobEntity;
-
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    if (result.TryFindEntity("Job", out jobEntity))
-        //    {
-        //        // obtain the name specified by the user -text in LUIS result is different
-        //        var friendlyJobId = jobEntity.GetEntityOriginalText(result.Query);
-
-        //        IList<RunbookJob> automationJobs = context.GetAutomationJobs(subscriptionId);
-        //        if (automationJobs != null)
-        //        {
-        //            var selectedJob = automationJobs.SingleOrDefault(x => !string.IsNullOrWhiteSpace(x.FriendlyJobId) 
-        //                    && x.FriendlyJobId.Equals(friendlyJobId, StringComparison.InvariantCultureIgnoreCase));
-
-        //            if (selectedJob == null)
-        //            {
-        //                await context.PostAsync($"The job with id '{friendlyJobId}' was not found.");
-        //                context.Wait(this.MessageReceived);
-        //                return;
-        //            }
-
-        //            var jobOutput = await new AzureRepository().GetAutomationJobOutputAsync(accessToken, subscriptionId, selectedJob.ResourceGroupName, selectedJob.AutomationAccountName, selectedJob.JobId);
-
-        //            var outputMessage = string.IsNullOrWhiteSpace(jobOutput) ? $"No output for job '{friendlyJobId}'" : jobOutput;
-
-        //            await context.PostAsync(outputMessage);
-        //        }
-        //        else
-        //        {
-        //            await context.PostAsync($"The job with id '{friendlyJobId}' was not found.");
-        //        }
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync("No runbook job id was specified. Try 'show <jobId> output'.");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //[LuisIntent("ShowRunbookDescription")]
-        //public async Task ShowRunbookDescriptionAsync(IDialogContext context, LuisResult result)
-        //{
-        //    EntityRecommendation runbookEntity;
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-
-        //    var availableAutomationAccounts = await new AzureRepository().ListRunbooksAsync(accessToken, subscriptionId);
-
-        //    // check if the user specified a runbook name in the command
-        //    if (result.TryFindEntity("Runbook", out runbookEntity))
-        //    {
-        //        // obtain the name specified by the user - text in LUIS result is different
-        //        var runbookName = runbookEntity.GetEntityOriginalText(result.Query);
-
-        //        // ensure that the runbook exists in at least one of the automation accounts
-        //        var selectedAutomationAccounts = availableAutomationAccounts.Where(x => x.Runbooks.Any(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)));
-
-        //        if (selectedAutomationAccounts == null || !selectedAutomationAccounts.Any())
-        //        {
-        //            await context.PostAsync($"The '{runbookName}' runbook was not found in any of your automation accounts.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-
-        //        if (selectedAutomationAccounts.Count() == 1)
-        //        {
-        //            var automationAccount = selectedAutomationAccounts.Single();
-        //            var runbook = automationAccount.Runbooks.Single(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase));
-        //            var description = await new AzureRepository().GetAutomationRunbookDescriptionAsync(accessToken, subscriptionId, automationAccount.ResourceGroup, automationAccount.AutomationAccountName, runbook.RunbookName) ?? "No description";
-        //            await context.PostAsync(description);
-        //            context.Wait(this.MessageReceived);
-        //        }
-        //        else
-        //        {
-        //            var message = $"I found the runbook '{runbookName}' in multiple automation accounts. Showing the description of all of them:";
-
-        //            foreach (var automationAccount in selectedAutomationAccounts)
-        //            {
-        //                message += $"\n\r {automationAccount.AutomationAccountName}";
-        //                foreach (var runbook in automationAccount.Runbooks)
-        //                {
-        //                    if (runbook.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase))
-        //                    {
-        //                        var description = await new AzureRepository().GetAutomationRunbookDescriptionAsync(accessToken, subscriptionId, automationAccount.ResourceGroup, automationAccount.AutomationAccountName, runbook.RunbookName) ?? "No description";
-
-        //                        message += $"\n\r• {description}";
-        //                    }
-        //                }
-        //            }
-
-        //            await context.PostAsync(message);
-        //            context.Wait(this.MessageReceived);
-        //        }
-        //    }
-        //    else
-        //    {
-        //        await context.PostAsync($"No runbook was specified. Please try again specifying a runbook name.");
-        //        context.Wait(this.MessageReceived);
-        //    }
-        //}
-
-        //[LuisIntent("Logout")]
-        //public async Task Logout(IDialogContext context, LuisResult result)
-        //{
-        //    context.Cleanup();
-        //    await context.Logout();
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //private async Task ResumeAfterAuth(IDialogContext context, IAwaitable<string> result)
-        //{
-        //    var message = await result;
-
-        //    await context.PostAsync(message);
-
-        //    await this.UseSubscriptionAsync(context, new LuisResult());
-        //}
-
-        //private async Task StartRunbookParametersAsync(IDialogContext context, IAwaitable<RunbookFormState> result)
-        //{
-        //    try
-        //    {
-        //        var runbookFormState = await result;
-        //        context.StoreRunbookFormState(runbookFormState);
-
-        //        await this.RunbookParametersFormComplete(context, null);
-        //    }
-        //    catch (FormCanceledException<RunbookFormState> e)
-        //    {
-        //        string reply;
-
-        //        if (e.InnerException == null)
-        //        {
-        //            reply = "You have canceled the operation. What would you like to do next?";
-        //        }
-        //        else
-        //        {
-        //            reply = $"Oops! Something went wrong :(. Technical Details: {e.InnerException.Message}";
-        //        }
-
-        //        await context.PostAsync(reply);
-
-        //        context.Wait(this.MessageReceived);
-        //    }
-        //}
-
-        //private async Task RunbookParametersFormComplete(IDialogContext context, RunbookParameterFormState runbookParameterFormState)
-        //{
-        //    var runbookFormState = context.GetRunbookFormState();
-        //    if (runbookParameterFormState != null)
-        //    {
-        //        runbookFormState.RunbookParameters.Add(runbookParameterFormState);
-        //        context.StoreRunbookFormState(runbookFormState);
-        //    }
-
-        //    var nextRunbookParameter = runbookFormState.SelectedRunbook.RunbookParameters.OrderBy(param => param.Position).FirstOrDefault(
-        //        availableParam => !runbookFormState.RunbookParameters.Any(stateParam => availableParam.ParameterName == stateParam.ParameterName));
-
-        //    if (nextRunbookParameter == null)
-        //    {
-        //        context.CleanupRunbookFormState();
-        //        await this.RunbookFormComplete(context, runbookFormState);
-        //        return;
-        //    }
-
-        //    var formState = new RunbookParameterFormState(nextRunbookParameter.IsMandatory, nextRunbookParameter.Position == 0, runbookFormState.SelectedRunbook.RunbookName)
-        //    {
-        //        ParameterName = nextRunbookParameter.ParameterName
-        //    };
-
-        //    var form = new FormDialog<RunbookParameterFormState>(
-        //        formState,
-        //        EntityForms.BuildRunbookParametersForm,
-        //        FormOptions.PromptInStart);
-
-        //    context.Call(form, this.RunbookParameterFormComplete);
-        //}
-
-        //private async Task RunbookParameterFormComplete(IDialogContext context, IAwaitable<RunbookParameterFormState> result)
-        //{
-        //    try
-        //    {
-        //        var runbookParameterFormState = await result;
-
-        //        await this.RunbookParametersFormComplete(context, runbookParameterFormState);
-        //    }
-        //    catch (FormCanceledException<RunbookParameterFormState> e)
-        //    {
-        //        context.CleanupRunbookFormState();
-
-        //        string reply;
-
-        //        if (e.InnerException == null)
-        //        {
-        //            reply = "You have canceled the operation. What would you like to do next?";
-        //        }
-        //        else
-        //        {
-        //            reply = $"Oops! Something went wrong :(. Technical Details: {e.InnerException.Message}";
-        //        }
-
-        //        await context.PostAsync(reply);
-
-        //        context.Wait(this.MessageReceived);
-        //    }
-        //}
-
-        //        private async Task RunbookFormComplete(IDialogContext context, RunbookFormState runbookFormState)
-        //        {
-        //            try
-        //            {
-        //                var accessToken = await context.GetAccessToken(resourceId.Value);
-
-        //                if (string.IsNullOrEmpty(accessToken))
-        //                {
-        //                    return;
-        //                }
-
-        //                var runbookJob = await new AzureRepository().StartRunbookAsync(
-        //                    accessToken,
-        //                    runbookFormState.SelectedAutomationAccount.SubscriptionId,
-        //                    runbookFormState.SelectedAutomationAccount.ResourceGroup,
-        //                    runbookFormState.SelectedAutomationAccount.AutomationAccountName,
-        //                    runbookFormState.RunbookName,
-        //                    runbookFormState.RunbookParameters.Where(param => !string.IsNullOrWhiteSpace(param.ParameterValue))
-        //                        .ToDictionary(param => param.ParameterName, param => param.ParameterValue));
-
-        //                IList<RunbookJob> automationJobs = context.GetAutomationJobs(runbookFormState.SelectedAutomationAccount.SubscriptionId);
-        //                if (automationJobs == null)
-        //                {
-        //                    runbookJob.FriendlyJobId = AutomationJobsHelper.NextFriendlyJobId(automationJobs);
-        //                    automationJobs = new List<RunbookJob> { runbookJob };
-        //                }
-        //                else
-        //                {
-        //                    runbookJob.FriendlyJobId = AutomationJobsHelper.NextFriendlyJobId(automationJobs);
-        //                    automationJobs.Add(runbookJob);
-        //                }
-
-        //                context.StoreAutomationJobs(runbookFormState.SelectedAutomationAccount.SubscriptionId, automationJobs);
-
-        //                await context.PostAsync($"Created Job '{runbookJob.JobId}' for the '{runbookFormState.RunbookName}' runbook in '{runbookFormState.AutomationAccountName}' automation account. You'll receive a message when it is completed.");
-
-        //                var notCompletedStatusList = new List<string> { "Stopped", "Suspended", "Failed" };
-        //                var completedStatusList = new List<string> { "Completed" };
-        //                var notifyStatusList = new List<string> { "Running" };
-        //                notifyStatusList.AddRange(completedStatusList);
-        //                notifyStatusList.AddRange(notCompletedStatusList);
-
-        //                accessToken = await context.GetAccessToken(resourceId.Value);
-
-        //                if (string.IsNullOrEmpty(accessToken))
-        //                {
-        //                    return;
-        //                }
-
-        //#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        //                CheckLongRunningOperationStatus(
-        //                    context,
-        //                    runbookJob,
-        //                    accessToken,
-        //                    new AzureRepository().GetAutomationJobAsync,
-        //                    rj => rj.EndDateTime.HasValue,
-        //                    (previous, last, job) =>
-        //                    {
-        //                        if (!string.Equals(previous?.Status, last?.Status) && notifyStatusList.Contains(last.Status))
-        //                        {
-        //                            if (notCompletedStatusList.Contains(last.Status))
-        //                            {
-        //                                return $"The runbook '{job.RunbookName}' (job '{job.JobId}') did not complete with status '{last.Status}'. Please go to the Azure Portal for more detailed information on why.";
-        //                            }
-        //                            else if (completedStatusList.Contains(last.Status))
-        //                            {
-        //                                return $"Runbook '{job.RunbookName}' is currently in '{last.Status}' status. Type **show {job.FriendlyJobId} output** to see the output.";
-        //                            }
-        //                            else
-        //                            {
-        //                                return $"Runbook '{job.RunbookName}' job '{job.JobId}' is currently in '{last.Status}' status.";
-        //                            }
-        //                        }
-
-        //                        return null;
-        //                    });
-        //#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        //            }
-        //            catch (Exception e)
-        //            {
-        //                await context.PostAsync($"Oops! Something went wrong :(. Technical Details: {e.InnerException.Message}");
-        //            }
-
-        //            context.Wait(this.MessageReceived);
-        //        }
-
-        //private async Task ProcessVirtualMachineActionAsync(
-        //    IDialogContext context,
-        //    LuisResult result,
-        //    Operations operation,
-        //    ResumeAfter<VirtualMachineFormState> resume)
-        //{
-        //    EntityRecommendation virtualMachineEntity;
-
-        //    // retrieve the list virtual machines from the subscription
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-        //    var availableVMs = (await new AzureRepository().ListVirtualMachinesAsync(accessToken, subscriptionId)).ToList();
-
-        //    // check if the user specified a virtual machine name in the command
-        //    if (result.TryFindEntity("VirtualMachine", out virtualMachineEntity))
-        //    {
-        //        // obtain the name specified by the user - text in LUIS result is different
-        //        var virtualMachineName = virtualMachineEntity.GetEntityOriginalText(result.Query);
-
-        //        // ensure that the virtual machine exists in the subscription
-        //        var selectedVM = availableVMs.FirstOrDefault(p => p.Name.Equals(virtualMachineName, StringComparison.InvariantCultureIgnoreCase));
-        //        if (selectedVM == null)
-        //        {
-        //            await context.PostAsync($"The '{virtualMachineName}' virtual machine was not found in the current subscription.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-
-        //        // ensure that the virtual machine is in the correct power state for the requested operation
-        //        if ((operation == Operations.Start && (selectedVM.PowerState == VirtualMachinePowerState.Starting || selectedVM.PowerState == VirtualMachinePowerState.Running))
-        //           || (operation == Operations.Shutdown && (selectedVM.PowerState == VirtualMachinePowerState.Stopping || selectedVM.PowerState == VirtualMachinePowerState.Stopped))
-        //           || (operation == Operations.Stop && (selectedVM.PowerState == VirtualMachinePowerState.Deallocating || selectedVM.PowerState == VirtualMachinePowerState.Deallocated)))
-        //        {
-        //            var powerState = selectedVM.PowerState.ToString().ToLower();
-        //            await context.PostAsync($"The '{virtualMachineName}' virtual machine is already {powerState}.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-
-        //        virtualMachineEntity.Entity = selectedVM.Name;
-        //    }
-
-        //    // retrieve the list of VMs that are in the correct power state
-        //    var validPowerStates = VirtualMachineHelper.RetrieveValidPowerStateByOperation(operation);
-
-        //    var candidateVMs = availableVMs.Where(vm => validPowerStates.Contains(vm.PowerState)).ToList();
-        //    if (candidateVMs.Any())
-        //    {
-        //        // prompt the user to select a VM from the list
-        //        var form = new FormDialog<VirtualMachineFormState>(
-        //            new VirtualMachineFormState(candidateVMs, operation),
-        //            EntityForms.BuildVirtualMachinesForm,
-        //            FormOptions.PromptInStart,
-        //            result.Entities);
-
-        //        context.Call(form, resume);
-        //    }
-        //    else
-        //    {
-        //        var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
-        //        await context.PostAsync($"No virtual machines that can be {operationText} were found in the current subscription.");
-        //        context.Wait(this.MessageReceived);
-        //    }
-        //}
-
-        //private async Task ProcessAllVirtualMachinesActionAsync(
-        //   IDialogContext context,
-        //   LuisResult result,
-        //   Operations operation,
-        //   ResumeAfter<AllVirtualMachinesFormState> resume)
-        //{
-        //    EntityRecommendation resourceGroupEntity;
-
-        //    var accessToken = await context.GetAccessToken(resourceId.Value);
-        //    if (string.IsNullOrEmpty(accessToken))
-        //    {
-        //        return;
-        //    }
-
-        //    var subscriptionId = context.GetSubscriptionId();
-        //    var availableVMs = (await new AzureRepository().ListVirtualMachinesAsync(accessToken, subscriptionId)).ToList();
-
-        //    // retrieve the list of VMs that are in the correct power state
-        //    var validPowerStates = VirtualMachineHelper.RetrieveValidPowerStateByOperation(operation);
-        //    IEnumerable<VirtualMachine> candidateVMs = null;
-
-        //    if (result.TryFindEntity("ResourceGroup", out resourceGroupEntity))
-        //    {
-        //        // obtain the name specified by the user - text in LUIS result is different
-        //        var resourceGroup = resourceGroupEntity.GetEntityOriginalText(result.Query);
-
-        //        candidateVMs = availableVMs.Where(vm => vm.ResourceGroup.Equals(resourceGroup, StringComparison.InvariantCultureIgnoreCase)).ToList();
-
-        //        if (candidateVMs == null || !candidateVMs.Any())
-        //        {
-        //            var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
-        //            await context.PostAsync($"The {resourceGroup} resource group doesn't contain VMs or doesn't exist in the current subscription.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-
-        //        candidateVMs = candidateVMs.Where(vm => validPowerStates.Contains(vm.PowerState)).ToList();
-
-        //        if (candidateVMs == null || !candidateVMs.Any())
-        //        {
-        //            var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
-        //            await context.PostAsync($"No virtual machines that can be {operationText} were found in the {resourceGroup} resource group of the current subscription.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-        //    }
-        //    else
-        //    {
-        //        candidateVMs = availableVMs.Where(vm => validPowerStates.Contains(vm.PowerState)).ToList();
-
-        //        if (!candidateVMs.Any())
-        //        {
-        //            var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
-        //            await context.PostAsync($"No virtual machines that can be {operationText} were found in the current subscription.");
-        //            context.Wait(this.MessageReceived);
-        //            return;
-        //        }
-        //    }
-
-        //    // prompt the user to select a VM from the list
-        //    var form = new FormDialog<AllVirtualMachinesFormState>(
-        //        new AllVirtualMachinesFormState(candidateVMs, operation),
-        //        EntityForms.BuildAllVirtualMachinesForm,
-        //        FormOptions.PromptInStart,
-        //        null);
-
-        //    context.Call(form, resume);
-        //}
-
-        //private async Task StartVirtualMachineFormComplete(IDialogContext context, IAwaitable<VirtualMachineFormState> result)
-        //{
-        //    Func<string, string> preMessageHandler = vm => $"Starting the '{vm}' virtual machine...";
-
-        //    Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
-        //    {
-        //        var statusMessage = operationStatus ? "was started successfully" : "failed to start";
-        //        return $"The '{vmName}' virtual machine {statusMessage}.";
-        //    };
-
-        //    await this.ProcessVirtualMachineFormComplete(
-        //        context,
-        //        result,
-        //        new AzureRepository().StartVirtualMachineAsync,
-        //        preMessageHandler,
-        //        notifyLongRunningOperationHandler);
-        //}
-
-        //private async Task StopVirtualMachineFormComplete(IDialogContext context, IAwaitable<VirtualMachineFormState> result)
-        //{
-        //    Func<string, string> preMessageHandler = vm => $"Stopping the '{vm}' virtual machine...";
-
-        //    Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
-        //    {
-        //        var statusMessage = operationStatus ? "was stopped successfully" : "failed to stop";
-        //        return $"The '{vmName}' virtual machine {statusMessage}.";
-        //    };
-
-        //    await this.ProcessVirtualMachineFormComplete(
-        //        context,
-        //        result,
-        //        new AzureRepository().DeallocateVirtualMachineAsync,
-        //        preMessageHandler,
-        //        notifyLongRunningOperationHandler);
-        //}
-
-        //private async Task ShutdownVirtualMachineFormComplete(IDialogContext context, IAwaitable<VirtualMachineFormState> result)
-        //{
-        //    Func<string, string> preMessageHandler = vm => $"Shutting down the '{vm}' virtual machine...";
-
-        //    Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
-        //    {
-        //        var statusMessage = operationStatus ? "was shut down successfully" : "failed to shutdown";
-        //        return $"The '{vmName}' virtual machine {statusMessage}.";
-        //    };
-
-        //    await this.ProcessVirtualMachineFormComplete(
-        //        context,
-        //        result,
-        //        new AzureRepository().PowerOffVirtualMachineAsync,
-        //        preMessageHandler,
-        //        notifyLongRunningOperationHandler);
-        //}
-
-        //private async Task ProcessVirtualMachineFormComplete(
-        //    IDialogContext context, 
-        //    IAwaitable<VirtualMachineFormState> result, 
-        //    Func<string, string, string, string, Task<bool>> operationHandler, 
-        //    Func<string, string> preMessageHandler, 
-        //    Func<bool, string, string> notifyLongRunningOperationHandler)
-        //{
-        //    try
-        //    {
-        //        var virtualMachineFormState = await result;
-        //        var vm = virtualMachineFormState.SelectedVM;
-
-        //        await context.PostAsync(preMessageHandler(vm.Name));
-
-        //        var accessToken = await context.GetAccessToken(resourceId.Value);
-        //        if (string.IsNullOrEmpty(accessToken))
-        //        {
-        //            return;
-        //        }
-
-        //        operationHandler(accessToken, vm.SubscriptionId, vm.ResourceGroup, vm.Name)
-        //            .NotifyLongRunningOperation(context, notifyLongRunningOperationHandler, vm.Name);
-        //    }
-        //    catch (FormCanceledException<VirtualMachineFormState>)
-        //    {
-        //        await context.PostAsync("You have canceled the operation. What would you like to do next?");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
-
-        //private async Task StartAllVirtualMachinesFormComplete(IDialogContext context, IAwaitable<AllVirtualMachinesFormState> result)
-        //{
-        //    Func<string, string> preMessageHandler = vms => $"Starting the following virtual machines: {vms}";
-
-        //    Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
-        //            {
-        //                var statusMessage = operationStatus ? "was started successfully" : "failed to start";
-        //                return $"The '{vmName}' virtual machine {statusMessage}.";
-        //            };
-
-        //    await this.ProcessAllVirtualMachinesFormComplete(
-        //        context,
-        //        result, 
-        //        new AzureRepository().StartVirtualMachineAsync,
-        //        preMessageHandler, 
-        //        notifyLongRunningOperationHandler);
-        //}
-
-        //private async Task StopAllVirtualMachinesFormComplete(IDialogContext context, IAwaitable<AllVirtualMachinesFormState> result)
-        //{
-        //    Func<string, string> preMessageHandler = vms => $"Stopping the following virtual machines: {vms}";
-
-        //    Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
-        //    {
-        //        var statusMessage = operationStatus ? "was stopped successfully" : "failed to stop";
-        //        return $"The '{vmName}' virtual machine {statusMessage}.";
-        //    };
-
-        //    await this.ProcessAllVirtualMachinesFormComplete(
-        //        context,
-        //        result, 
-        //        new AzureRepository().DeallocateVirtualMachineAsync,
-        //        preMessageHandler, 
-        //        notifyLongRunningOperationHandler);
-        //}
-
-        //private async Task ShutdownAllVirtualMachinesFormComplete(IDialogContext context, IAwaitable<AllVirtualMachinesFormState> result)
-        //{
-        //    Func<string, string> preMessageHandler = vms => $"Shutting down the following virtual machines: {vms}";
-
-        //    Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
-        //    {
-        //        var statusMessage = operationStatus ? "was shut down successfully" : "failed to shutdown";
-        //        return $"The '{vmName}' virtual machine {statusMessage}.";
-        //    };
-
-        //    await this.ProcessAllVirtualMachinesFormComplete(
-        //        context,
-        //        result,
-        //        new AzureRepository().PowerOffVirtualMachineAsync,
-        //        preMessageHandler,
-        //        notifyLongRunningOperationHandler);
-        //}
-
-        //private async Task ProcessAllVirtualMachinesFormComplete(
-        //    IDialogContext context, 
-        //    IAwaitable<AllVirtualMachinesFormState> result, 
-        //    Func<string, string, string, string, Task<bool>> operationHandler, 
-        //    Func<string, string> preMessageHandler, 
-        //    Func<bool, string, string> notifyLongRunningOperationHandler)
-        //{
-        //    try
-        //    {
-        //        var allVirtualMachineFormState = await result;
-
-        //        await context.PostAsync(preMessageHandler(allVirtualMachineFormState.VirtualMachines));
-
-        //        var accessToken = await context.GetAccessToken(resourceId.Value);
-        //        if (string.IsNullOrEmpty(accessToken))
-        //        {
-        //            return;
-        //        }
-
-        //        Parallel.ForEach(
-        //            allVirtualMachineFormState.AvailableVMs, 
-        //            vm =>
-        //            {
-        //                operationHandler(accessToken, vm.SubscriptionId, vm.ResourceGroup, vm.Name)
-        //                    .NotifyLongRunningOperation(context, notifyLongRunningOperationHandler, vm.Name);
-        //            });
-        //    }
-        //    catch (FormCanceledException<AllVirtualMachinesFormState>)
-        //    {
-        //        await context.PostAsync("You have canceled the operation. What would you like to do next?");
-        //    }
-
-        //    context.Wait(this.MessageReceived);
-        //}
+        [LuisIntent("ListSubscriptions")]
+        public async Task ListSubscriptionsAsync(IDialogContext context, LuisResult result)
+        {
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptions = await new AzureRepository().ListSubscriptionsAsync(accessToken);
+            
+            int index = 0;
+            var subscriptionsText = subscriptions.Aggregate(
+                string.Empty,
+                (current, next) =>
+                    {
+                        index++;
+                        return current += $"\r\n{index}. {next.DisplayName}";
+                    });
+
+            await context.PostAsync($"Your subscriptions are: {subscriptionsText}");
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("CurrentSubscription")]
+        public async Task GetCurrentSubscriptionAsync(IDialogContext context, LuisResult result)
+        {
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            var currentSubscription = await new AzureRepository().GetSubscription(accessToken, subscriptionId);
+
+            await context.PostAsync($"Your current subscription is '{currentSubscription.DisplayName}'.");
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("UseSubscription")]
+        public async Task UseSubscriptionAsync(IDialogContext context, LuisResult result)
+        {
+            EntityRecommendation subscriptionEntity;
+
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                context.Wait(this.MessageReceived);
+                return;
+            }
+
+            var availableSubscriptions = await new AzureRepository().ListSubscriptionsAsync(accessToken);
+
+            // check if the user specified a subscription name in the command
+            if (result.TryFindEntity("Subscription", out subscriptionEntity))
+            {
+                // obtain the name specified by the user - text in LUIS result is different
+                var subscriptionName = subscriptionEntity.GetEntityOriginalText(result.Query);
+
+                // ensure that the subscription exists
+                var selectedSubscription = availableSubscriptions.FirstOrDefault(p => p.DisplayName.Equals(subscriptionName, StringComparison.InvariantCultureIgnoreCase));
+                if (selectedSubscription == null)
+                {
+                    await context.PostAsync($"The '{subscriptionName}' subscription was not found.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+
+                subscriptionEntity.Entity = selectedSubscription.DisplayName;
+                subscriptionEntity.Type = "SubscriptionId";
+            }
+
+            var formState = new SubscriptionFormState(availableSubscriptions);
+
+            if (availableSubscriptions.Count() == 1)
+            {
+                formState.SubscriptionId = availableSubscriptions.Single().SubscriptionId;
+                formState.DisplayName = availableSubscriptions.Single().DisplayName;
+            }
+
+            var form = new FormDialog<SubscriptionFormState>(
+                formState,
+                EntityForms.BuildSubscriptionForm,
+                FormOptions.PromptInStart,
+                result.Entities);
+
+            context.Call(form, this.UseSubscriptionFormComplete);
+        }
+
+        [LuisIntent("ListVms")]
+        public async Task ListVmsAsync(IDialogContext context, LuisResult result)
+        {
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            var virtualMachines = (await new AzureRepository().ListVirtualMachinesAsync(accessToken, subscriptionId)).ToList();
+            if (virtualMachines.Any())
+            {
+                var virtualMachinesText = virtualMachines.Aggregate(
+                     string.Empty,
+                    (current, next) =>
+                    {
+                        return current += $"\n\r• {next}";
+                    });
+
+                await context.PostAsync($"Available VMs are:\r\n {virtualMachinesText}");
+            }
+            else
+            {
+                await context.PostAsync("No virtual machines were found in the current subscription.");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("StartVm")]
+        public async Task StartVmAsync(IDialogContext context, LuisResult result)
+        {
+            await this.ProcessVirtualMachineActionAsync(context, result, Operations.Start, this.StartVirtualMachineFormComplete);
+        }
+
+        [LuisIntent("StartAllVms")]
+        public async Task StartAllVmsAsync(IDialogContext context, LuisResult result)
+        {
+            await this.ProcessAllVirtualMachinesActionAsync(context, result, Operations.Start, this.StartAllVirtualMachinesFormComplete);
+        }
+
+        [LuisIntent("StopVm")]
+        public async Task StopVmAsync(IDialogContext context, LuisResult result)
+        {
+            await this.ProcessVirtualMachineActionAsync(context, result, Operations.Stop, this.StopVirtualMachineFormComplete);
+        }
+
+        [LuisIntent("StopAllVms")]
+        public async Task StopAllVmsAsync(IDialogContext context, LuisResult result)
+        {
+            await this.ProcessAllVirtualMachinesActionAsync(context, result, Operations.Stop, this.StopAllVirtualMachinesFormComplete);
+        }
+
+        [LuisIntent("ShutdownVm")]
+        public async Task ShutdownVmAsync(IDialogContext context, LuisResult result)
+        {
+            await this.ProcessVirtualMachineActionAsync(context, result, Operations.Shutdown, this.ShutdownVirtualMachineFormComplete);
+        }
+
+        [LuisIntent("ShutdownAllVms")]
+        public async Task ShutdownAllVmsAsync(IDialogContext context, LuisResult result)
+        {
+            await this.ProcessAllVirtualMachinesActionAsync(context, result, Operations.Shutdown, this.ShutdownAllVirtualMachinesFormComplete);
+        }
+
+        [LuisIntent("ListRunbooks")]
+        public async Task ListRunbooksAsync(IDialogContext context, LuisResult result)
+        {
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            var automationAccounts = await new AzureRepository().ListRunbooksAsync(accessToken, subscriptionId);
+
+            if (automationAccounts.Any())
+            {
+                var automationAccountsWithRunbooks = automationAccounts.Where(x => x.Runbooks.Any());
+
+                if (automationAccountsWithRunbooks.Any())
+                {
+                    var messageText = "Available runbooks are:";
+
+                    var singleAutomationAccount = automationAccountsWithRunbooks.Count() == 1;
+
+                    if (singleAutomationAccount)
+                    {
+                        messageText = $"Listing all runbooks from {automationAccountsWithRunbooks.Single().AutomationAccountName}";
+                    }
+
+                    var runbooksText = automationAccountsWithRunbooks.Aggregate(
+                         string.Empty,
+                        (current, next) =>
+                        {
+                            var innerRunbooksText = next.Runbooks.Aggregate(
+                                string.Empty,
+                                (currentRunbooks, nextRunbook) =>
+                                {
+                                    return currentRunbooks += $"\n\r• {nextRunbook}";
+                                });
+
+                            return current += singleAutomationAccount ? innerRunbooksText : $"\n\r {next.AutomationAccountName}" + innerRunbooksText;
+                        });
+
+                    var showDescriptionText = "Type **show runbook <name> description** to get details on any runbook.";
+                    await context.PostAsync($"{messageText}:\r\n {runbooksText} \r\n\r\n {showDescriptionText}");
+                }
+                else
+                {
+                    await context.PostAsync($"The automation accounts found in the current subscription doesn't have runbooks.");
+                }
+            }
+            else
+            {
+                await context.PostAsync("No runbooks listed since no automations accounts were found in the current subscription.");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("ListAutomationAccounts")]
+        public async Task ListAutomationAccountsAsync(IDialogContext context, LuisResult result)
+        {
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            var automationAccounts = await new AzureRepository().ListAutomationAccountsAsync(accessToken, subscriptionId);
+            if (automationAccounts.Any())
+            {
+                var automationAccountsText = automationAccounts.Aggregate(
+                     string.Empty,
+                    (current, next) =>
+                    {
+                        return current += $"\n\r• {next.AutomationAccountName}";
+                    });
+
+                await context.PostAsync($"Available automations accounts are:\r\n {automationAccountsText}");
+            }
+            else
+            {
+                await context.PostAsync("No automations accounts were found in the current subscription.");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("RunRunbook")]
+        public async Task StartRunbookAsync(IDialogContext context, LuisResult result)
+        {
+            EntityRecommendation runbookEntity;
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            var availableAutomationAccounts = await new AzureRepository().ListRunbooksAsync(accessToken, subscriptionId);
+
+            // check if the user specified a runbook name in the command
+            if (result.TryFindEntity("Runbook", out runbookEntity))
+            {
+                // obtain the name specified by the user - text in LUIS result is different
+                var runbookName = runbookEntity.GetEntityOriginalText(result.Query);
+
+                EntityRecommendation automationAccountEntity;
+
+                if (result.TryFindEntity("AutomationAccount", out automationAccountEntity))
+                {
+                    // obtain the name specified by the user - text in LUIS result is different
+                    var automationAccountName = automationAccountEntity.GetEntityOriginalText(result.Query);
+
+                    var selectedAutomationAccount = availableAutomationAccounts.SingleOrDefault(x => x.AutomationAccountName.Equals(automationAccountName, StringComparison.InvariantCultureIgnoreCase));
+
+                    if (selectedAutomationAccount == null)
+                    {
+                        await context.PostAsync($"The '{automationAccountName}' automation account was not found in the current subscription");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    var runbook = selectedAutomationAccount.Runbooks.SingleOrDefault(x => x.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase));
+
+                    // ensure that the runbook exists in the specified automation account
+                    if (runbook == null)
+                    {
+                        await context.PostAsync($"The '{runbookName}' runbook was not found in the '{automationAccountName}' automation account.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    if (!runbook.RunbookState.Equals("Published", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        await context.PostAsync($"The '{runbookName}' runbook that you are trying to run is not published (State: {runbook.RunbookState}). Please go the Azure Portal and publish the runbook.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    runbookEntity.Entity = runbookName;
+                    runbookEntity.Type = "RunbookName";
+
+                    automationAccountEntity.Entity = selectedAutomationAccount.AutomationAccountName;
+                    automationAccountEntity.Type = "AutomationAccountName";
+                }
+                else
+                {
+                    // ensure that the runbook exists in at least one of the automation accounts
+                    var selectedAutomationAccounts = availableAutomationAccounts.Where(x => x.Runbooks.Any(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)));
+
+                    if (selectedAutomationAccounts == null || !selectedAutomationAccounts.Any())
+                    {
+                        await context.PostAsync($"The '{runbookName}' runbook was not found in any of your automation accounts.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    var runbooks = selectedAutomationAccounts.SelectMany(x => x.Runbooks.Where(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)
+                                                                            && r.RunbookState.Equals("Published", StringComparison.InvariantCultureIgnoreCase)));
+
+                    if (runbooks == null || !runbooks.Any())
+                    {
+                        await context.PostAsync($"The '{runbookName}' runbook that you are trying to run is not Published. Please go the Azure Portal and publish the runbook.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    runbookEntity.Entity = runbookName;
+                    runbookEntity.Type = "RunbookName";
+
+                    // todo: handle runbooks with same name in different automation accounts
+                    availableAutomationAccounts = selectedAutomationAccounts.ToList();
+                }
+            }
+
+            if (availableAutomationAccounts.Any())
+            {
+                var formState = new RunbookFormState(availableAutomationAccounts);
+
+                if (availableAutomationAccounts.Count() == 1)
+                {
+                    formState.AutomationAccountName = availableAutomationAccounts.Single().AutomationAccountName;
+                }
+
+                var form = new FormDialog<RunbookFormState>(
+                    formState,
+                    EntityForms.BuildRunbookForm,
+                    FormOptions.PromptInStart,
+                    result.Entities);
+                context.Call(form, this.StartRunbookParametersAsync);
+            }
+            else
+            {
+                await context.PostAsync($"No automations accounts were found in the current subscription. Please create an Azure automation account or switch to a subscription which has an automation account in it.");
+                context.Wait(this.MessageReceived);
+            }
+        }
+
+        [LuisIntent("StatusJob")]
+        public async Task StatusJobAsync(IDialogContext context, LuisResult result)
+        {
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            IList<RunbookJob> automationJobs = context.GetAutomationJobs(subscriptionId);
+            if (automationJobs != null && automationJobs.Any())
+            {
+                var messageBuilder = new StringBuilder();
+                messageBuilder.AppendLine("|Id|Runbook|Start Time|End Time|Status|");
+                messageBuilder.AppendLine("|---|---|---|---|---|");
+                foreach (var job in automationJobs)
+                {
+                    var automationJob = await new AzureRepository().GetAutomationJobAsync(accessToken, subscriptionId, job.ResourceGroupName, job.AutomationAccountName, job.JobId, configureAwait: false);
+                    var startDateTime = automationJob.StartDateTime?.ToString("g") ?? string.Empty;
+                    var endDateTime = automationJob.EndDateTime?.ToString("g") ?? string.Empty;
+                    var status = automationJob.Status ?? string.Empty;
+                    messageBuilder.AppendLine($"|{job.FriendlyJobId}|{automationJob.RunbookName}|{startDateTime}|{endDateTime}|{status}|");
+                }
+
+                await context.PostAsync(messageBuilder.ToString());
+            }
+            else
+            {
+                await context.PostAsync("No Runbook Jobs were created in the current session. To create a new Runbook Job type: Start Runbook.");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("ShowJobOutput")]
+        public async Task ShowJobOutputAsync(IDialogContext context, LuisResult result)
+        {
+            EntityRecommendation jobEntity;
+
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            if (result.TryFindEntity("Job", out jobEntity))
+            {
+                // obtain the name specified by the user -text in LUIS result is different
+                var friendlyJobId = jobEntity.GetEntityOriginalText(result.Query);
+
+                IList<RunbookJob> automationJobs = context.GetAutomationJobs(subscriptionId);
+                if (automationJobs != null)
+                {
+                    var selectedJob = automationJobs.SingleOrDefault(x => !string.IsNullOrWhiteSpace(x.FriendlyJobId)
+                            && x.FriendlyJobId.Equals(friendlyJobId, StringComparison.InvariantCultureIgnoreCase));
+
+                    if (selectedJob == null)
+                    {
+                        await context.PostAsync($"The job with id '{friendlyJobId}' was not found.");
+                        context.Wait(this.MessageReceived);
+                        return;
+                    }
+
+                    var jobOutput = await new AzureRepository().GetAutomationJobOutputAsync(accessToken, subscriptionId, selectedJob.ResourceGroupName, selectedJob.AutomationAccountName, selectedJob.JobId);
+
+                    var outputMessage = string.IsNullOrWhiteSpace(jobOutput) ? $"No output for job '{friendlyJobId}'" : jobOutput;
+
+                    await context.PostAsync(outputMessage);
+                }
+                else
+                {
+                    await context.PostAsync($"The job with id '{friendlyJobId}' was not found.");
+                }
+            }
+            else
+            {
+                await context.PostAsync("No runbook job id was specified. Try 'show <jobId> output'.");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        [LuisIntent("ShowRunbookDescription")]
+        public async Task ShowRunbookDescriptionAsync(IDialogContext context, LuisResult result)
+        {
+            EntityRecommendation runbookEntity;
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+
+            var availableAutomationAccounts = await new AzureRepository().ListRunbooksAsync(accessToken, subscriptionId);
+
+            // check if the user specified a runbook name in the command
+            if (result.TryFindEntity("Runbook", out runbookEntity))
+            {
+                // obtain the name specified by the user - text in LUIS result is different
+                var runbookName = runbookEntity.GetEntityOriginalText(result.Query);
+
+                // ensure that the runbook exists in at least one of the automation accounts
+                var selectedAutomationAccounts = availableAutomationAccounts.Where(x => x.Runbooks.Any(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase)));
+
+                if (selectedAutomationAccounts == null || !selectedAutomationAccounts.Any())
+                {
+                    await context.PostAsync($"The '{runbookName}' runbook was not found in any of your automation accounts.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+
+                if (selectedAutomationAccounts.Count() == 1)
+                {
+                    var automationAccount = selectedAutomationAccounts.Single();
+                    var runbook = automationAccount.Runbooks.Single(r => r.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase));
+                    var description = await new AzureRepository().GetAutomationRunbookDescriptionAsync(accessToken, subscriptionId, automationAccount.ResourceGroup, automationAccount.AutomationAccountName, runbook.RunbookName) ?? "No description";
+                    await context.PostAsync(description);
+                    context.Wait(this.MessageReceived);
+                }
+                else
+                {
+                    var message = $"I found the runbook '{runbookName}' in multiple automation accounts. Showing the description of all of them:";
+
+                    foreach (var automationAccount in selectedAutomationAccounts)
+                    {
+                        message += $"\n\r {automationAccount.AutomationAccountName}";
+                        foreach (var runbook in automationAccount.Runbooks)
+                        {
+                            if (runbook.RunbookName.Equals(runbookName, StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                var description = await new AzureRepository().GetAutomationRunbookDescriptionAsync(accessToken, subscriptionId, automationAccount.ResourceGroup, automationAccount.AutomationAccountName, runbook.RunbookName) ?? "No description";
+
+                                message += $"\n\r• {description}";
+                            }
+                        }
+                    }
+
+                    await context.PostAsync(message);
+                    context.Wait(this.MessageReceived);
+                }
+            }
+            else
+            {
+                await context.PostAsync($"No runbook was specified. Please try again specifying a runbook name.");
+                context.Wait(this.MessageReceived);
+            }
+        }
+
+        [LuisIntent("Logout")]
+        public async Task Logout(IDialogContext context, LuisResult result)
+        {
+            context.Cleanup();
+            await context.Logout();
+
+            context.Wait(this.MessageReceived);
+        }
+
+        private async Task ResumeAfterAuth(IDialogContext context, IAwaitable<string> result)
+        {
+            var message = await result;
+
+            await context.PostAsync(message);
+
+            await this.UseSubscriptionAsync(context, new LuisResult());
+        }
+
+        private async Task StartRunbookParametersAsync(IDialogContext context, IAwaitable<RunbookFormState> result)
+        {
+            try
+            {
+                var runbookFormState = await result;
+                context.StoreRunbookFormState(runbookFormState);
+
+                await this.RunbookParametersFormComplete(context, null);
+            }
+            catch (FormCanceledException<RunbookFormState> e)
+            {
+                string reply;
+
+                if (e.InnerException == null)
+                {
+                    reply = "You have canceled the operation. What would you like to do next?";
+                }
+                else
+                {
+                    reply = $"Oops! Something went wrong :(. Technical Details: {e.InnerException.Message}";
+                }
+
+                await context.PostAsync(reply);
+
+                context.Wait(this.MessageReceived);
+            }
+        }
+
+        private async Task RunbookParametersFormComplete(IDialogContext context, RunbookParameterFormState runbookParameterFormState)
+        {
+            var runbookFormState = context.GetRunbookFormState();
+            if (runbookParameterFormState != null)
+            {
+                runbookFormState.RunbookParameters.Add(runbookParameterFormState);
+                context.StoreRunbookFormState(runbookFormState);
+            }
+
+            var nextRunbookParameter = runbookFormState.SelectedRunbook.RunbookParameters.OrderBy(param => param.Position).FirstOrDefault(
+                availableParam => !runbookFormState.RunbookParameters.Any(stateParam => availableParam.ParameterName == stateParam.ParameterName));
+
+            if (nextRunbookParameter == null)
+            {
+                context.CleanupRunbookFormState();
+                await this.RunbookFormComplete(context, runbookFormState);
+                return;
+            }
+
+            var formState = new RunbookParameterFormState(nextRunbookParameter.IsMandatory, nextRunbookParameter.Position == 0, runbookFormState.SelectedRunbook.RunbookName)
+            {
+                ParameterName = nextRunbookParameter.ParameterName
+            };
+
+            var form = new FormDialog<RunbookParameterFormState>(
+                formState,
+                EntityForms.BuildRunbookParametersForm,
+                FormOptions.PromptInStart);
+
+            context.Call(form, this.RunbookParameterFormComplete);
+        }
+
+        private async Task RunbookParameterFormComplete(IDialogContext context, IAwaitable<RunbookParameterFormState> result)
+        {
+            try
+            {
+                var runbookParameterFormState = await result;
+
+                await this.RunbookParametersFormComplete(context, runbookParameterFormState);
+            }
+            catch (FormCanceledException<RunbookParameterFormState> e)
+            {
+                context.CleanupRunbookFormState();
+
+                string reply;
+
+                if (e.InnerException == null)
+                {
+                    reply = "You have canceled the operation. What would you like to do next?";
+                }
+                else
+                {
+                    reply = $"Oops! Something went wrong :(. Technical Details: {e.InnerException.Message}";
+                }
+
+                await context.PostAsync(reply);
+
+                context.Wait(this.MessageReceived);
+            }
+        }
+
+        private async Task RunbookFormComplete(IDialogContext context, RunbookFormState runbookFormState)
+        {
+            try
+            {
+                var accessToken = await context.GetAccessToken(resourceId.Value);
+
+                if (string.IsNullOrEmpty(accessToken))
+                {
+                    return;
+                }
+
+                var runbookJob = await new AzureRepository().StartRunbookAsync(
+                    accessToken,
+                    runbookFormState.SelectedAutomationAccount.SubscriptionId,
+                    runbookFormState.SelectedAutomationAccount.ResourceGroup,
+                    runbookFormState.SelectedAutomationAccount.AutomationAccountName,
+                    runbookFormState.RunbookName,
+                    runbookFormState.RunbookParameters.Where(param => !string.IsNullOrWhiteSpace(param.ParameterValue))
+                        .ToDictionary(param => param.ParameterName, param => param.ParameterValue));
+
+                IList<RunbookJob> automationJobs = context.GetAutomationJobs(runbookFormState.SelectedAutomationAccount.SubscriptionId);
+                if (automationJobs == null)
+                {
+                    runbookJob.FriendlyJobId = AutomationJobsHelper.NextFriendlyJobId(automationJobs);
+                    automationJobs = new List<RunbookJob> { runbookJob };
+                }
+                else
+                {
+                    runbookJob.FriendlyJobId = AutomationJobsHelper.NextFriendlyJobId(automationJobs);
+                    automationJobs.Add(runbookJob);
+                }
+
+                context.StoreAutomationJobs(runbookFormState.SelectedAutomationAccount.SubscriptionId, automationJobs);
+
+                await context.PostAsync($"Created Job '{runbookJob.JobId}' for the '{runbookFormState.RunbookName}' runbook in '{runbookFormState.AutomationAccountName}' automation account. You'll receive a message when it is completed.");
+
+                var notCompletedStatusList = new List<string> { "Stopped", "Suspended", "Failed" };
+                var completedStatusList = new List<string> { "Completed" };
+                var notifyStatusList = new List<string> { "Running" };
+                notifyStatusList.AddRange(completedStatusList);
+                notifyStatusList.AddRange(notCompletedStatusList);
+
+                accessToken = await context.GetAccessToken(resourceId.Value);
+
+                if (string.IsNullOrEmpty(accessToken))
+                {
+                    return;
+                }
+
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                CheckLongRunningOperationStatus(
+                    context,
+                    runbookJob,
+                    accessToken,
+                    new AzureRepository().GetAutomationJobAsync,
+                    rj => rj.EndDateTime.HasValue,
+                    (previous, last, job) =>
+                    {
+                        if (!string.Equals(previous?.Status, last?.Status) && notifyStatusList.Contains(last.Status))
+                        {
+                            if (notCompletedStatusList.Contains(last.Status))
+                            {
+                                return $"The runbook '{job.RunbookName}' (job '{job.JobId}') did not complete with status '{last.Status}'. Please go to the Azure Portal for more detailed information on why.";
+                            }
+                            else if (completedStatusList.Contains(last.Status))
+                            {
+                                return $"Runbook '{job.RunbookName}' is currently in '{last.Status}' status. Type **show {job.FriendlyJobId} output** to see the output.";
+                            }
+                            else
+                            {
+                                return $"Runbook '{job.RunbookName}' job '{job.JobId}' is currently in '{last.Status}' status.";
+                            }
+                        }
+
+                        return null;
+                    });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            }
+            catch (Exception e)
+            {
+                await context.PostAsync($"Oops! Something went wrong :(. Technical Details: {e.InnerException.Message}");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        private async Task ProcessVirtualMachineActionAsync(
+            IDialogContext context,
+            LuisResult result,
+            Operations operation,
+            ResumeAfter<VirtualMachineFormState> resume)
+        {
+            EntityRecommendation virtualMachineEntity;
+
+            // retrieve the list virtual machines from the subscription
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+            var availableVMs = (await new AzureRepository().ListVirtualMachinesAsync(accessToken, subscriptionId)).ToList();
+
+            // check if the user specified a virtual machine name in the command
+            if (result.TryFindEntity("VirtualMachine", out virtualMachineEntity))
+            {
+                // obtain the name specified by the user - text in LUIS result is different
+                var virtualMachineName = virtualMachineEntity.GetEntityOriginalText(result.Query);
+
+                // ensure that the virtual machine exists in the subscription
+                var selectedVM = availableVMs.FirstOrDefault(p => p.Name.Equals(virtualMachineName, StringComparison.InvariantCultureIgnoreCase));
+                if (selectedVM == null)
+                {
+                    await context.PostAsync($"The '{virtualMachineName}' virtual machine was not found in the current subscription.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+
+                // ensure that the virtual machine is in the correct power state for the requested operation
+                if ((operation == Operations.Start && (selectedVM.PowerState == VirtualMachinePowerState.Starting || selectedVM.PowerState == VirtualMachinePowerState.Running))
+                   || (operation == Operations.Shutdown && (selectedVM.PowerState == VirtualMachinePowerState.Stopping || selectedVM.PowerState == VirtualMachinePowerState.Stopped))
+                   || (operation == Operations.Stop && (selectedVM.PowerState == VirtualMachinePowerState.Deallocating || selectedVM.PowerState == VirtualMachinePowerState.Deallocated)))
+                {
+                    var powerState = selectedVM.PowerState.ToString().ToLower();
+                    await context.PostAsync($"The '{virtualMachineName}' virtual machine is already {powerState}.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+
+                virtualMachineEntity.Entity = selectedVM.Name;
+            }
+
+            // retrieve the list of VMs that are in the correct power state
+            var validPowerStates = VirtualMachineHelper.RetrieveValidPowerStateByOperation(operation);
+
+            var candidateVMs = availableVMs.Where(vm => validPowerStates.Contains(vm.PowerState)).ToList();
+            if (candidateVMs.Any())
+            {
+                // prompt the user to select a VM from the list
+                var form = new FormDialog<VirtualMachineFormState>(
+                    new VirtualMachineFormState(candidateVMs, operation),
+                    EntityForms.BuildVirtualMachinesForm,
+                    FormOptions.PromptInStart,
+                    result.Entities);
+
+                context.Call(form, resume);
+            }
+            else
+            {
+                var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
+                await context.PostAsync($"No virtual machines that can be {operationText} were found in the current subscription.");
+                context.Wait(this.MessageReceived);
+            }
+        }
+
+        private async Task ProcessAllVirtualMachinesActionAsync(
+           IDialogContext context,
+           LuisResult result,
+           Operations operation,
+           ResumeAfter<AllVirtualMachinesFormState> resume)
+        {
+            EntityRecommendation resourceGroupEntity;
+
+            var accessToken = await context.GetAccessToken(resourceId.Value);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return;
+            }
+
+            var subscriptionId = context.GetSubscriptionId();
+            var availableVMs = (await new AzureRepository().ListVirtualMachinesAsync(accessToken, subscriptionId)).ToList();
+
+            // retrieve the list of VMs that are in the correct power state
+            var validPowerStates = VirtualMachineHelper.RetrieveValidPowerStateByOperation(operation);
+            IEnumerable<VirtualMachine> candidateVMs = null;
+
+            if (result.TryFindEntity("ResourceGroup", out resourceGroupEntity))
+            {
+                // obtain the name specified by the user - text in LUIS result is different
+                var resourceGroup = resourceGroupEntity.GetEntityOriginalText(result.Query);
+
+                candidateVMs = availableVMs.Where(vm => vm.ResourceGroup.Equals(resourceGroup, StringComparison.InvariantCultureIgnoreCase)).ToList();
+
+                if (candidateVMs == null || !candidateVMs.Any())
+                {
+                    var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
+                    await context.PostAsync($"The {resourceGroup} resource group doesn't contain VMs or doesn't exist in the current subscription.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+
+                candidateVMs = candidateVMs.Where(vm => validPowerStates.Contains(vm.PowerState)).ToList();
+
+                if (candidateVMs == null || !candidateVMs.Any())
+                {
+                    var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
+                    await context.PostAsync($"No virtual machines that can be {operationText} were found in the {resourceGroup} resource group of the current subscription.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+            }
+            else
+            {
+                candidateVMs = availableVMs.Where(vm => validPowerStates.Contains(vm.PowerState)).ToList();
+
+                if (!candidateVMs.Any())
+                {
+                    var operationText = VirtualMachineHelper.RetrieveOperationTextByOperation(operation);
+                    await context.PostAsync($"No virtual machines that can be {operationText} were found in the current subscription.");
+                    context.Wait(this.MessageReceived);
+                    return;
+                }
+            }
+
+            // prompt the user to select a VM from the list
+            var form = new FormDialog<AllVirtualMachinesFormState>(
+                new AllVirtualMachinesFormState(candidateVMs, operation),
+                EntityForms.BuildAllVirtualMachinesForm,
+                FormOptions.PromptInStart,
+                null);
+
+            context.Call(form, resume);
+        }
+
+        private async Task StartVirtualMachineFormComplete(IDialogContext context, IAwaitable<VirtualMachineFormState> result)
+        {
+            Func<string, string> preMessageHandler = vm => $"Starting the '{vm}' virtual machine...";
+
+            Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
+            {
+                var statusMessage = operationStatus ? "was started successfully" : "failed to start";
+                return $"The '{vmName}' virtual machine {statusMessage}.";
+            };
+
+            await this.ProcessVirtualMachineFormComplete(
+                context,
+                result,
+                new AzureRepository().StartVirtualMachineAsync,
+                preMessageHandler,
+                notifyLongRunningOperationHandler);
+        }
+
+        private async Task StopVirtualMachineFormComplete(IDialogContext context, IAwaitable<VirtualMachineFormState> result)
+        {
+            Func<string, string> preMessageHandler = vm => $"Stopping the '{vm}' virtual machine...";
+
+            Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
+            {
+                var statusMessage = operationStatus ? "was stopped successfully" : "failed to stop";
+                return $"The '{vmName}' virtual machine {statusMessage}.";
+            };
+
+            await this.ProcessVirtualMachineFormComplete(
+                context,
+                result,
+                new AzureRepository().DeallocateVirtualMachineAsync,
+                preMessageHandler,
+                notifyLongRunningOperationHandler);
+        }
+
+        private async Task ShutdownVirtualMachineFormComplete(IDialogContext context, IAwaitable<VirtualMachineFormState> result)
+        {
+            Func<string, string> preMessageHandler = vm => $"Shutting down the '{vm}' virtual machine...";
+
+            Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
+            {
+                var statusMessage = operationStatus ? "was shut down successfully" : "failed to shutdown";
+                return $"The '{vmName}' virtual machine {statusMessage}.";
+            };
+
+            await this.ProcessVirtualMachineFormComplete(
+                context,
+                result,
+                new AzureRepository().PowerOffVirtualMachineAsync,
+                preMessageHandler,
+                notifyLongRunningOperationHandler);
+        }
+
+        private async Task ProcessVirtualMachineFormComplete(
+            IDialogContext context,
+            IAwaitable<VirtualMachineFormState> result,
+            Func<string, string, string, string, Task<bool>> operationHandler,
+            Func<string, string> preMessageHandler,
+            Func<bool, string, string> notifyLongRunningOperationHandler)
+        {
+            try
+            {
+                var virtualMachineFormState = await result;
+                var vm = virtualMachineFormState.SelectedVM;
+
+                await context.PostAsync(preMessageHandler(vm.Name));
+
+                var accessToken = await context.GetAccessToken(resourceId.Value);
+                if (string.IsNullOrEmpty(accessToken))
+                {
+                    return;
+                }
+
+                operationHandler(accessToken, vm.SubscriptionId, vm.ResourceGroup, vm.Name)
+                    .NotifyLongRunningOperation(context, notifyLongRunningOperationHandler, vm.Name);
+            }
+            catch (FormCanceledException<VirtualMachineFormState>)
+            {
+                await context.PostAsync("You have canceled the operation. What would you like to do next?");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
+
+        private async Task StartAllVirtualMachinesFormComplete(IDialogContext context, IAwaitable<AllVirtualMachinesFormState> result)
+        {
+            Func<string, string> preMessageHandler = vms => $"Starting the following virtual machines: {vms}";
+
+            Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
+                    {
+                        var statusMessage = operationStatus ? "was started successfully" : "failed to start";
+                        return $"The '{vmName}' virtual machine {statusMessage}.";
+                    };
+
+            await this.ProcessAllVirtualMachinesFormComplete(
+                context,
+                result,
+                new AzureRepository().StartVirtualMachineAsync,
+                preMessageHandler,
+                notifyLongRunningOperationHandler);
+        }
+
+        private async Task StopAllVirtualMachinesFormComplete(IDialogContext context, IAwaitable<AllVirtualMachinesFormState> result)
+        {
+            Func<string, string> preMessageHandler = vms => $"Stopping the following virtual machines: {vms}";
+
+            Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
+            {
+                var statusMessage = operationStatus ? "was stopped successfully" : "failed to stop";
+                return $"The '{vmName}' virtual machine {statusMessage}.";
+            };
+
+            await this.ProcessAllVirtualMachinesFormComplete(
+                context,
+                result,
+                new AzureRepository().DeallocateVirtualMachineAsync,
+                preMessageHandler,
+                notifyLongRunningOperationHandler);
+        }
+
+        private async Task ShutdownAllVirtualMachinesFormComplete(IDialogContext context, IAwaitable<AllVirtualMachinesFormState> result)
+        {
+            Func<string, string> preMessageHandler = vms => $"Shutting down the following virtual machines: {vms}";
+
+            Func<bool, string, string> notifyLongRunningOperationHandler = (operationStatus, vmName) =>
+            {
+                var statusMessage = operationStatus ? "was shut down successfully" : "failed to shutdown";
+                return $"The '{vmName}' virtual machine {statusMessage}.";
+            };
+
+            await this.ProcessAllVirtualMachinesFormComplete(
+                context,
+                result,
+                new AzureRepository().PowerOffVirtualMachineAsync,
+                preMessageHandler,
+                notifyLongRunningOperationHandler);
+        }
+
+        private async Task ProcessAllVirtualMachinesFormComplete(
+            IDialogContext context,
+            IAwaitable<AllVirtualMachinesFormState> result,
+            Func<string, string, string, string, Task<bool>> operationHandler,
+            Func<string, string> preMessageHandler,
+            Func<bool, string, string> notifyLongRunningOperationHandler)
+        {
+            try
+            {
+                var allVirtualMachineFormState = await result;
+
+                await context.PostAsync(preMessageHandler(allVirtualMachineFormState.VirtualMachines));
+
+                var accessToken = await context.GetAccessToken(resourceId.Value);
+                if (string.IsNullOrEmpty(accessToken))
+                {
+                    return;
+                }
+
+                Parallel.ForEach(
+                    allVirtualMachineFormState.AvailableVMs,
+                    vm =>
+                    {
+                        operationHandler(accessToken, vm.SubscriptionId, vm.ResourceGroup, vm.Name)
+                            .NotifyLongRunningOperation(context, notifyLongRunningOperationHandler, vm.Name);
+                    });
+            }
+            catch (FormCanceledException<AllVirtualMachinesFormState>)
+            {
+                await context.PostAsync("You have canceled the operation. What would you like to do next?");
+            }
+
+            context.Wait(this.MessageReceived);
+        }
 
         private async Task UseSubscriptionFormComplete(IDialogContext context, IAwaitable<SubscriptionFormState> result)
         {
@@ -1183,7 +1182,7 @@
             if (result)
             {
                 context.Cleanup();
-                //await context.Logout();
+                await context.Logout();
             }
 
             context.Wait(this.MessageReceived);

--- a/AzureBot/Dialogs/ActionDialog.cs
+++ b/AzureBot/Dialogs/ActionDialog.cs
@@ -24,7 +24,7 @@
     public class ActionDialog : LuisDialog<string>
     {
         private static Lazy<string> resourceId = new Lazy<string>(() => ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
-        
+        private bool serviceUrlSet = false;
         [LuisIntent("")]
         [LuisIntent("None")]
         public async Task None(IDialogContext context, LuisResult result)
@@ -56,6 +56,11 @@
         {
             var message = await item;
 
+            if (!serviceUrlSet)
+            {
+                context.PrivateConversationData.SetValue("ServiceUrl", message.ServiceUrl);
+                serviceUrlSet = true;
+            }
             if (message.Text.ToLowerInvariant().Contains("help"))
             {
                 await base.MessageReceived(context, item);

--- a/AzureBot/Dialogs/DialogExtensions.cs
+++ b/AzureBot/Dialogs/DialogExtensions.cs
@@ -59,14 +59,15 @@
         {
             if (!string.IsNullOrEmpty(messageText))
             {
-                var reply = context.MakeMessage();
-                reply.Text = messageText;
+                //var reply = context.MakeMessage();
+                //reply.Text = messageText;
 
-                using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, reply))
-                {
-                    var client = scope.Resolve<IConnectorClient>();
-                    await client.Conversations.ReplyToActivityAsync((Activity)reply);
-                }
+                //using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, reply))
+                //{
+                //    var client = scope.Resolve<IConnectorClient>();
+                //    await client.Conversations.ReplyToActivityAsync((Activity)reply);
+                //}
+                await context.PostAsync(messageText);
             }
         }
     }

--- a/AzureBot/Dialogs/DialogExtensions.cs
+++ b/AzureBot/Dialogs/DialogExtensions.cs
@@ -59,15 +59,13 @@
         {
             if (!string.IsNullOrEmpty(messageText))
             {
-                //var reply = context.MakeMessage();
-                //reply.Text = messageText;
-
-                //using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, reply))
-                //{
-                //    var client = scope.Resolve<IConnectorClient>();
-                //    await client.Conversations.ReplyToActivityAsync((Activity)reply);
-                //}
-                await context.PostAsync(messageText);
+                var reply = context.MakeMessage();
+                reply.Text = messageText;
+                using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, reply))
+                {
+                    var client = scope.Resolve<IConnectorClient>();
+                    await client.Conversations.ReplyToActivityAsync((Activity)reply);
+                }
             }
         }
     }

--- a/AzureBot/Dialogs/DialogExtensions.cs
+++ b/AzureBot/Dialogs/DialogExtensions.cs
@@ -9,7 +9,6 @@
     using Microsoft.Bot.Builder.Dialogs.Internals;
     using Microsoft.Bot.Builder.Luis.Models;
     using Microsoft.Bot.Connector;
-
     public static class DialogExtensions
     {
         public static void NotifyLongRunningOperation<T>(this Task<T> operation, IDialogContext context, Func<T, string> handler)
@@ -59,13 +58,11 @@
         {
             if (!string.IsNullOrEmpty(messageText))
             {
+                string serviceUrl = context.PrivateConversationData.Get<string>("ServiceUrl");
+                var connector = new ConnectorClient(new Uri(serviceUrl));
                 var reply = context.MakeMessage();
                 reply.Text = messageText;
-                using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, reply))
-                {
-                    var client = scope.Resolve<IConnectorClient>();
-                    await client.Conversations.ReplyToActivityAsync((Activity)reply);
-                }
+                await connector.Conversations.ReplyToActivityAsync((Activity)reply);
             }
         }
     }

--- a/AzureBot/Global.asax.cs
+++ b/AzureBot/Global.asax.cs
@@ -2,7 +2,7 @@
 {
     using System.Configuration;
     using System.Web.Http;
-    //using AuthBot.Models;
+    using AuthBot.Models;
 
     public class WebApiApplication : System.Web.HttpApplication
     {
@@ -10,12 +10,12 @@
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
 
-            //AuthSettings.Mode = ConfigurationManager.AppSettings["ActiveDirectory.Mode"];
-            //AuthSettings.EndpointUrl = ConfigurationManager.AppSettings["ActiveDirectory.EndpointUrl"];
-            //AuthSettings.Tenant = ConfigurationManager.AppSettings["ActiveDirectory.Tenant"];
-            //AuthSettings.RedirectUrl = ConfigurationManager.AppSettings["ActiveDirectory.RedirectUrl"];
-            //AuthSettings.ClientId = ConfigurationManager.AppSettings["ActiveDirectory.ClientId"];
-            //AuthSettings.ClientSecret = ConfigurationManager.AppSettings["ActiveDirectory.ClientSecret"];
+            AuthSettings.Mode = ConfigurationManager.AppSettings["ActiveDirectory.Mode"];
+            AuthSettings.EndpointUrl = ConfigurationManager.AppSettings["ActiveDirectory.EndpointUrl"];
+            AuthSettings.Tenant = ConfigurationManager.AppSettings["ActiveDirectory.Tenant"];
+            AuthSettings.RedirectUrl = ConfigurationManager.AppSettings["ActiveDirectory.RedirectUrl"];
+            AuthSettings.ClientId = ConfigurationManager.AppSettings["ActiveDirectory.ClientId"];
+            AuthSettings.ClientSecret = ConfigurationManager.AppSettings["ActiveDirectory.ClientSecret"];
         }
     }
 }

--- a/AzureBot/Web.config
+++ b/AzureBot/Web.config
@@ -7,8 +7,8 @@
   <appSettings>
     <!-- update these with your Bot Id, Microsoft App Id and your Microsoft App passwords -->
     <add key="BotId" value="YourBotId" />
-    <add key="MicrosoftAppId" value="YourMicrosoftAppId" />
-    <add key="MicrosoftAppPassword" value="YourMicrosoftAppPassword" />
+    <add key="MicrosoftAppId" value="YOUR-APP-ID" />
+    <add key="MicrosoftAppPassword" value="YOUR-APP-PASSWORD" />
 
     <!-- Authentication settings -->
     <add key="ActiveDirectory.Mode" value="v1" />
@@ -16,8 +16,9 @@
     <add key="ActiveDirectory.EndpointUrl" value="https://login.microsoftonline.com" />
     <add key="ActiveDirectory.Tenant" value="YOUR-TENANT" />
     <add key="ActiveDirectory.ClientId" value="YOUR-CLIENT-ID" />
-    <add key="ActiveDirectory.ClientSecret" value="YOUR-CLIENT-SECRET" />    
+    <add key="ActiveDirectory.ClientSecret" value="YOUR-CLIENT-SECRET" />
     <add key="ActiveDirectory.RedirectUrl" value="YOUR-REDIRECT-URL" />
+
 
     <!-- Azure ARM settings -->
     <add key="ResourceManager.EndpointUrl" value="https://management.azure.com/" />
@@ -32,7 +33,7 @@
   -->
   <system.web>
     <customErrors mode="Off" /> 
-    <compilation debug="true" targetFramework="4.6" />
+    <compilation debug="true" batch="false" targetFramework="4.6" />
     <httpRuntime targetFramework="4.6" />
   </system.web>
   <system.webServer>
@@ -52,48 +53,20 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/AzureBot/Web.config
+++ b/AzureBot/Web.config
@@ -7,8 +7,8 @@
   <appSettings>
     <!-- update these with your Bot Id, Microsoft App Id and your Microsoft App passwords -->
     <add key="BotId" value="YourBotId" />
-    <add key="MicrosoftAppId" value="YOUR-APP-ID" />
-    <add key="MicrosoftAppPassword" value="YOUR-APP-PASSWORD" />
+    <add key="MicrosoftAppId" value="YourMicrosoftAppId" />
+    <add key="MicrosoftAppPassword" value="YourMicrosoftAppPassword" />
 
     <!-- Authentication settings -->
     <add key="ActiveDirectory.Mode" value="v1" />
@@ -18,7 +18,6 @@
     <add key="ActiveDirectory.ClientId" value="YOUR-CLIENT-ID" />
     <add key="ActiveDirectory.ClientSecret" value="YOUR-CLIENT-SECRET" />
     <add key="ActiveDirectory.RedirectUrl" value="YOUR-REDIRECT-URL" />
-
 
     <!-- Azure ARM settings -->
     <add key="ResourceManager.EndpointUrl" value="https://management.azure.com/" />
@@ -62,7 +61,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/AzureBot/Web.config
+++ b/AzureBot/Web.config
@@ -6,9 +6,9 @@
 <configuration>
   <appSettings>
     <!-- update these with your Bot Id, Microsoft App Id and your Microsoft App passwords -->
-    <add key="BotId" value="YourBotId" />
-    <add key="MicrosoftAppId" value="YourMicrosoftAppId" />
-    <add key="MicrosoftAppPassword" value="YourMicrosoftAppPassword" />
+    <add key="BotId" value="YOUR-BOT-ID" />
+    <add key="MicrosoftAppId" value="YOUR-MICROSOFT-APP-ID" />
+    <add key="MicrosoftAppPassword" value="YOUR-MICROSOFT-APP-PASSWORD" />
 
     <!-- Authentication settings -->
     <add key="ActiveDirectory.Mode" value="v1" />

--- a/AzureBot/Web.config
+++ b/AzureBot/Web.config
@@ -91,6 +91,10 @@
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/AzureBot/packages.config
+++ b/AzureBot/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.Identity.Client" version="1.0.304142221-alpha" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.11.305310302-alpha" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net46" />
-  <package id="Microsoft.Rest.ClientRuntime" version="1.8.2" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net46" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net46" />
   <package id="System.AppContext" version="4.0.0" targetFramework="net46" />

--- a/AzureBot/packages.config
+++ b/AzureBot/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net46" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime" version="1.8.2" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net46" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />

--- a/AzureBot/packages.config
+++ b/AzureBot/packages.config
@@ -1,57 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.0-rc2-240" targetFramework="net46" />
+  <package id="AuthBot" version="3.0.2-alpha" targetFramework="net46" />
+  <package id="Autofac" version="4.0.0-rc3-309" targetFramework="net46" />
   <package id="autorest" version="0.16.0" targetFramework="net46" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.2.2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.2.2" targetFramework="net46" />
   <package id="Microsoft.Identity.Client" version="1.0.304142221-alpha" targetFramework="net46" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.11.305310302-alpha" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.12.0" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net46" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net46" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net46" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="9.0.1-beta1" targetFramework="net46" />
-  <package id="System.AppContext" version="4.0.0" targetFramework="net46" />
-  <package id="System.Collections" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Collections.Concurrent" version="4.0.12-rc2-24027" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
-  <package id="System.ComponentModel" version="4.0.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Diagnostics.Debug" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Diagnostics.StackTrace" version="4.0.0" targetFramework="net46" />
-  <package id="System.Diagnostics.Tools" version="4.0.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.11-rc2-24027" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net46" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.0.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net46" />
-  <package id="System.IO" version="4.1.0-rc2-24027" targetFramework="net46" />
-  <package id="System.IO.FileSystem" version="4.0.0" targetFramework="net46" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0" targetFramework="net46" />
-  <package id="System.Linq" version="4.1.0-rc2-24027" targetFramework="net46" />
-  <package id="System.Linq.Expressions" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Net.Http" version="4.0.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Net.Primitives" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Reflection" version="4.1.0-rc2-24027" targetFramework="net46" />
-  <package id="System.Reflection.Extensions" version="4.0.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net46" />
-  <package id="System.Reflection.Primitives" version="4.0.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Resources.ResourceManager" version="4.0.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Runtime" version="4.1.0-rc2-24027" targetFramework="net46" />
-  <package id="System.Runtime.Extensions" version="4.1.0-rc2-24027" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices" version="4.1.0-rc2-24027" targetFramework="net46" />
-  <package id="System.Runtime.Serialization.Json" version="4.0.2-rc2-24027" targetFramework="net46" />
-  <package id="System.Runtime.Serialization.Primitives" version="4.1.1-rc2-24027" targetFramework="net46" />
-  <package id="System.Text.Encoding" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Text.RegularExpressions" version="4.0.12-rc2-24027" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Threading.Tasks" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Xml.ReaderWriter" version="4.0.11-rc2-24027" targetFramework="net46" />
-  <package id="System.Xml.XDocument" version="4.0.11-rc2-24027" targetFramework="net46" />
+  <package id="System.IO" version="4.1.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.0.0" targetFramework="net46" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net46" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net46" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net46" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.Serialization.Json" version="4.0.2" targetFramework="net46" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net46" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net46" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net46" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Reversed Azure packages to deprecated version as the latest still has incompatibility issues with Microsoft.Client.Runtime used by Bot Framework.
Most commands now work in the emulator for V3. Long running replies needed updating to work.
Command Line and Tests projects still need updating.