### PR TITLE
Beta

### DIFF
--- a/AzureBot.Tests/RunbookTests.cs
+++ b/AzureBot.Tests/RunbookTests.cs
@@ -499,7 +499,7 @@
 
             var completionStep2 = new BotTestCase()
             {
-                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type *show job",
+                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type **show job",
             };
 
             var completionSteps = new List<BotTestCase>() { completionStep1, completionStep2 };

--- a/AzureBot.Tests/RunbookTests.cs
+++ b/AzureBot.Tests/RunbookTests.cs
@@ -332,7 +332,7 @@
 
             var completionStep2 = new BotTestCase()
             {
-                ExpectedReply = $"is currently in 'Completed' status. Type *show job",
+                ExpectedReply = $"is currently in 'Completed' status. Type **show job",
             };
 
             var completionSteps = new List<BotTestCase>() { completionStep1, completionStep2 };
@@ -380,7 +380,7 @@
 
             var completionStep2 = new BotTestCase()
             {
-                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type *show job",
+                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type **show job",
             };
 
             var completionSteps = new List<BotTestCase>() { completionStep1, completionStep2 };
@@ -416,7 +416,7 @@
 
             var completionStep2 = new BotTestCase()
             {
-                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type *show job",
+                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type **show job",
             };
 
             var completionSteps = new List<BotTestCase>() { completionStep1, completionStep2 };
@@ -475,7 +475,7 @@
             var step2 = new BotTestCase()
             {
                 Action = $"Yes",
-                ExpectedReply = $"If you're unsure what to input, type *quit* followed by *show runbook {runbook} description* to get more details.",
+                ExpectedReply = $"If you're unsure what to input, type **quit** followed by **show runbook {runbook} description** to get more details.",
             };
 
             var step3 = new BotTestCase()
@@ -536,7 +536,7 @@
 
             var completionStep2 = new BotTestCase()
             {
-                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type *show job",
+                ExpectedReply = $"Runbook '{runbook}' is currently in 'Completed' status. Type **show job",
                 Verified = (reply) =>
                 {
                     var jobIndex = reply.LastIndexOf("job");


### PR DESCRIPTION
These tests were failing as they had '\*\*' instead of '\*'. Unfortunately the ShouldShowStatusOfJobs and ShowJobOutputShouldNotifyWhenSpecifiedJobDoesntHaveOutput are still failing on the bot framework